### PR TITLE
prevent overlap by changing zIndex

### DIFF
--- a/dist/PublicLab.Editor.css
+++ b/dist/PublicLab.Editor.css
@@ -155,7 +155,7 @@ textarea.ple-textarea {
 .wk-prompt {
   border-radius: 10px;
   padding: 20px;
-  z-index: 2;
+  z-index: 999;
 }
 
 /* Following may be removed if this is resolved:

--- a/dist/PublicLab.Editor.js
+++ b/dist/PublicLab.Editor.js
@@ -1,4 +1,4 @@
-(function(){function r(e,n,t){function o(i,f){if(!n[i]){if(!e[i]){var c="function"==typeof require&&require;if(!f&&c)return c(i,!0);if(u)return u(i,!0);var a=new Error("Cannot find module '"+i+"'");throw a.code="MODULE_NOT_FOUND",a}var p=n[i]={exports:{}};e[i][0].call(p.exports,function(r){var n=e[i][1][r];return o(n||r)},p,p.exports,r,e,n,t)}return n[i].exports}for(var u="function"==typeof require&&require,i=0;i<t.length;i++)o(t[i]);return o}return r})()({1:[function(require,module,exports){
+(function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);var f=new Error("Cannot find module '"+o+"'");throw f.code="MODULE_NOT_FOUND",f}var l=n[o]={exports:{}};t[o][0].call(l.exports,function(e){var n=t[o][1][e];return s(n?n:e)},l,l.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(require,module,exports){
 'use strict';
 
 function assignment (result) {
@@ -231,7 +231,7 @@ module.exports = {
 };
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./eventmap":5,"custom-event":18}],5:[function(require,module,exports){
+},{"./eventmap":5,"custom-event":17}],5:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -323,8 +323,9 @@ function bullseye (el, target, options) {
     if (!tailor && target !== el) {
       p.y += target.offsetHeight;
     }
+    var context = o.context;
     el.style.left = p.x + 'px';
-    el.style.top = p.y + 'px';
+    el.style.top = (context ? context.offsetHeight : p.y) + 'px';
   }
 
   function destroy () {
@@ -336,7 +337,7 @@ function bullseye (el, target, options) {
 
 module.exports = bullseye;
 
-},{"./tailormade":7,"./throttle":8,"crossvent":16}],7:[function(require,module,exports){
+},{"./tailormade":7,"./throttle":8,"crossvent":15}],7:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -516,7 +517,7 @@ function tailormade (el, options) {
 module.exports = tailormade;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./throttle":8,"crossvent":16,"seleccion":145,"sell":147}],8:[function(require,module,exports){
+},{"./throttle":8,"crossvent":15,"seleccion":140,"sell":142}],8:[function(require,module,exports){
 'use strict';
 
 function throttle (fn, boundary) {
@@ -764,7 +765,7 @@ function find (el, type, fn) {
 }
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./eventmap":11,"custom-event":18}],11:[function(require,module,exports){
+},{"./eventmap":11,"custom-event":17}],11:[function(require,module,exports){
 arguments[4][5][0].apply(exports,arguments)
 },{"dup":5}],12:[function(require,module,exports){
 "use strict";
@@ -999,7 +1000,7 @@ function getXml(xhr) {
 
 function noop() {}
 
-},{"global/window":24,"is-function":64,"parse-headers":134,"xtend":204}],13:[function(require,module,exports){
+},{"global/window":23,"is-function":48,"parse-headers":130,"xtend":195}],13:[function(require,module,exports){
 'use strict';
 
 var ticky = require('ticky');
@@ -1011,7 +1012,7 @@ module.exports = function debounce (fn, args, ctx) {
   });
 };
 
-},{"ticky":150}],14:[function(require,module,exports){
+},{"ticky":145}],14:[function(require,module,exports){
 'use strict';
 
 var atoa = require('atoa');
@@ -1068,62 +1069,10 @@ module.exports = function emitter (thing, options) {
 };
 
 },{"./debounce":13,"atoa":2}],15:[function(require,module,exports){
-(function (global){
-
-var NativeCustomEvent = global.CustomEvent;
-
-function useNative () {
-  try {
-    var p = new NativeCustomEvent('cat', { detail: { foo: 'bar' } });
-    return  'cat' === p.type && 'bar' === p.detail.foo;
-  } catch (e) {
-  }
-  return false;
-}
-
-/**
- * Cross-browser `CustomEvent` constructor.
- *
- * https://developer.mozilla.org/en-US/docs/Web/API/CustomEvent.CustomEvent
- *
- * @public
- */
-
-module.exports = useNative() ? NativeCustomEvent :
-
-// IE >= 9
-'undefined' !== typeof document && 'function' === typeof document.createEvent ? function CustomEvent (type, params) {
-  var e = document.createEvent('CustomEvent');
-  if (params) {
-    e.initCustomEvent(type, params.bubbles, params.cancelable, params.detail);
-  } else {
-    e.initCustomEvent(type, false, false, void 0);
-  }
-  return e;
-} :
-
-// IE <= 8
-function CustomEvent (type, params) {
-  var e = document.createEventObject();
-  e.type = type;
-  if (params) {
-    e.bubbles = Boolean(params.bubbles);
-    e.cancelable = Boolean(params.cancelable);
-    e.detail = params.detail;
-  } else {
-    e.bubbles = false;
-    e.cancelable = false;
-    e.detail = void 0;
-  }
-  return e;
-}
-
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],16:[function(require,module,exports){
 arguments[4][10][0].apply(exports,arguments)
-},{"./eventmap":17,"custom-event":15,"dup":10}],17:[function(require,module,exports){
+},{"./eventmap":16,"custom-event":17,"dup":10}],16:[function(require,module,exports){
 arguments[4][5][0].apply(exports,arguments)
-},{"dup":5}],18:[function(require,module,exports){
+},{"dup":5}],17:[function(require,module,exports){
 (function (global){
 
 var NativeCustomEvent = global.CustomEvent;
@@ -1175,7 +1124,7 @@ function CustomEvent (type, params) {
 }
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],19:[function(require,module,exports){
+},{}],18:[function(require,module,exports){
 'use strict';
 
 require('string.prototype.repeat');
@@ -1862,7 +1811,7 @@ Domador.prototype.openCodeFence = function openCodeFence (el) {
 
 module.exports = parse;
 
-},{"./virtualWindowContext":20,"string.prototype.repeat":149}],20:[function(require,module,exports){
+},{"./virtualWindowContext":19,"string.prototype.repeat":144}],19:[function(require,module,exports){
 'use strict';
 
 if (!window.Node) {
@@ -1878,73 +1827,57 @@ function windowContext () {
 
 module.exports = windowContext;
 
-},{}],21:[function(require,module,exports){
+},{}],20:[function(require,module,exports){
 module.exports={"Aacute":"\u00C1","aacute":"\u00E1","Abreve":"\u0102","abreve":"\u0103","ac":"\u223E","acd":"\u223F","acE":"\u223E\u0333","Acirc":"\u00C2","acirc":"\u00E2","acute":"\u00B4","Acy":"\u0410","acy":"\u0430","AElig":"\u00C6","aelig":"\u00E6","af":"\u2061","Afr":"\uD835\uDD04","afr":"\uD835\uDD1E","Agrave":"\u00C0","agrave":"\u00E0","alefsym":"\u2135","aleph":"\u2135","Alpha":"\u0391","alpha":"\u03B1","Amacr":"\u0100","amacr":"\u0101","amalg":"\u2A3F","amp":"&","AMP":"&","andand":"\u2A55","And":"\u2A53","and":"\u2227","andd":"\u2A5C","andslope":"\u2A58","andv":"\u2A5A","ang":"\u2220","ange":"\u29A4","angle":"\u2220","angmsdaa":"\u29A8","angmsdab":"\u29A9","angmsdac":"\u29AA","angmsdad":"\u29AB","angmsdae":"\u29AC","angmsdaf":"\u29AD","angmsdag":"\u29AE","angmsdah":"\u29AF","angmsd":"\u2221","angrt":"\u221F","angrtvb":"\u22BE","angrtvbd":"\u299D","angsph":"\u2222","angst":"\u00C5","angzarr":"\u237C","Aogon":"\u0104","aogon":"\u0105","Aopf":"\uD835\uDD38","aopf":"\uD835\uDD52","apacir":"\u2A6F","ap":"\u2248","apE":"\u2A70","ape":"\u224A","apid":"\u224B","apos":"'","ApplyFunction":"\u2061","approx":"\u2248","approxeq":"\u224A","Aring":"\u00C5","aring":"\u00E5","Ascr":"\uD835\uDC9C","ascr":"\uD835\uDCB6","Assign":"\u2254","ast":"*","asymp":"\u2248","asympeq":"\u224D","Atilde":"\u00C3","atilde":"\u00E3","Auml":"\u00C4","auml":"\u00E4","awconint":"\u2233","awint":"\u2A11","backcong":"\u224C","backepsilon":"\u03F6","backprime":"\u2035","backsim":"\u223D","backsimeq":"\u22CD","Backslash":"\u2216","Barv":"\u2AE7","barvee":"\u22BD","barwed":"\u2305","Barwed":"\u2306","barwedge":"\u2305","bbrk":"\u23B5","bbrktbrk":"\u23B6","bcong":"\u224C","Bcy":"\u0411","bcy":"\u0431","bdquo":"\u201E","becaus":"\u2235","because":"\u2235","Because":"\u2235","bemptyv":"\u29B0","bepsi":"\u03F6","bernou":"\u212C","Bernoullis":"\u212C","Beta":"\u0392","beta":"\u03B2","beth":"\u2136","between":"\u226C","Bfr":"\uD835\uDD05","bfr":"\uD835\uDD1F","bigcap":"\u22C2","bigcirc":"\u25EF","bigcup":"\u22C3","bigodot":"\u2A00","bigoplus":"\u2A01","bigotimes":"\u2A02","bigsqcup":"\u2A06","bigstar":"\u2605","bigtriangledown":"\u25BD","bigtriangleup":"\u25B3","biguplus":"\u2A04","bigvee":"\u22C1","bigwedge":"\u22C0","bkarow":"\u290D","blacklozenge":"\u29EB","blacksquare":"\u25AA","blacktriangle":"\u25B4","blacktriangledown":"\u25BE","blacktriangleleft":"\u25C2","blacktriangleright":"\u25B8","blank":"\u2423","blk12":"\u2592","blk14":"\u2591","blk34":"\u2593","block":"\u2588","bne":"=\u20E5","bnequiv":"\u2261\u20E5","bNot":"\u2AED","bnot":"\u2310","Bopf":"\uD835\uDD39","bopf":"\uD835\uDD53","bot":"\u22A5","bottom":"\u22A5","bowtie":"\u22C8","boxbox":"\u29C9","boxdl":"\u2510","boxdL":"\u2555","boxDl":"\u2556","boxDL":"\u2557","boxdr":"\u250C","boxdR":"\u2552","boxDr":"\u2553","boxDR":"\u2554","boxh":"\u2500","boxH":"\u2550","boxhd":"\u252C","boxHd":"\u2564","boxhD":"\u2565","boxHD":"\u2566","boxhu":"\u2534","boxHu":"\u2567","boxhU":"\u2568","boxHU":"\u2569","boxminus":"\u229F","boxplus":"\u229E","boxtimes":"\u22A0","boxul":"\u2518","boxuL":"\u255B","boxUl":"\u255C","boxUL":"\u255D","boxur":"\u2514","boxuR":"\u2558","boxUr":"\u2559","boxUR":"\u255A","boxv":"\u2502","boxV":"\u2551","boxvh":"\u253C","boxvH":"\u256A","boxVh":"\u256B","boxVH":"\u256C","boxvl":"\u2524","boxvL":"\u2561","boxVl":"\u2562","boxVL":"\u2563","boxvr":"\u251C","boxvR":"\u255E","boxVr":"\u255F","boxVR":"\u2560","bprime":"\u2035","breve":"\u02D8","Breve":"\u02D8","brvbar":"\u00A6","bscr":"\uD835\uDCB7","Bscr":"\u212C","bsemi":"\u204F","bsim":"\u223D","bsime":"\u22CD","bsolb":"\u29C5","bsol":"\\","bsolhsub":"\u27C8","bull":"\u2022","bullet":"\u2022","bump":"\u224E","bumpE":"\u2AAE","bumpe":"\u224F","Bumpeq":"\u224E","bumpeq":"\u224F","Cacute":"\u0106","cacute":"\u0107","capand":"\u2A44","capbrcup":"\u2A49","capcap":"\u2A4B","cap":"\u2229","Cap":"\u22D2","capcup":"\u2A47","capdot":"\u2A40","CapitalDifferentialD":"\u2145","caps":"\u2229\uFE00","caret":"\u2041","caron":"\u02C7","Cayleys":"\u212D","ccaps":"\u2A4D","Ccaron":"\u010C","ccaron":"\u010D","Ccedil":"\u00C7","ccedil":"\u00E7","Ccirc":"\u0108","ccirc":"\u0109","Cconint":"\u2230","ccups":"\u2A4C","ccupssm":"\u2A50","Cdot":"\u010A","cdot":"\u010B","cedil":"\u00B8","Cedilla":"\u00B8","cemptyv":"\u29B2","cent":"\u00A2","centerdot":"\u00B7","CenterDot":"\u00B7","cfr":"\uD835\uDD20","Cfr":"\u212D","CHcy":"\u0427","chcy":"\u0447","check":"\u2713","checkmark":"\u2713","Chi":"\u03A7","chi":"\u03C7","circ":"\u02C6","circeq":"\u2257","circlearrowleft":"\u21BA","circlearrowright":"\u21BB","circledast":"\u229B","circledcirc":"\u229A","circleddash":"\u229D","CircleDot":"\u2299","circledR":"\u00AE","circledS":"\u24C8","CircleMinus":"\u2296","CirclePlus":"\u2295","CircleTimes":"\u2297","cir":"\u25CB","cirE":"\u29C3","cire":"\u2257","cirfnint":"\u2A10","cirmid":"\u2AEF","cirscir":"\u29C2","ClockwiseContourIntegral":"\u2232","CloseCurlyDoubleQuote":"\u201D","CloseCurlyQuote":"\u2019","clubs":"\u2663","clubsuit":"\u2663","colon":":","Colon":"\u2237","Colone":"\u2A74","colone":"\u2254","coloneq":"\u2254","comma":",","commat":"@","comp":"\u2201","compfn":"\u2218","complement":"\u2201","complexes":"\u2102","cong":"\u2245","congdot":"\u2A6D","Congruent":"\u2261","conint":"\u222E","Conint":"\u222F","ContourIntegral":"\u222E","copf":"\uD835\uDD54","Copf":"\u2102","coprod":"\u2210","Coproduct":"\u2210","copy":"\u00A9","COPY":"\u00A9","copysr":"\u2117","CounterClockwiseContourIntegral":"\u2233","crarr":"\u21B5","cross":"\u2717","Cross":"\u2A2F","Cscr":"\uD835\uDC9E","cscr":"\uD835\uDCB8","csub":"\u2ACF","csube":"\u2AD1","csup":"\u2AD0","csupe":"\u2AD2","ctdot":"\u22EF","cudarrl":"\u2938","cudarrr":"\u2935","cuepr":"\u22DE","cuesc":"\u22DF","cularr":"\u21B6","cularrp":"\u293D","cupbrcap":"\u2A48","cupcap":"\u2A46","CupCap":"\u224D","cup":"\u222A","Cup":"\u22D3","cupcup":"\u2A4A","cupdot":"\u228D","cupor":"\u2A45","cups":"\u222A\uFE00","curarr":"\u21B7","curarrm":"\u293C","curlyeqprec":"\u22DE","curlyeqsucc":"\u22DF","curlyvee":"\u22CE","curlywedge":"\u22CF","curren":"\u00A4","curvearrowleft":"\u21B6","curvearrowright":"\u21B7","cuvee":"\u22CE","cuwed":"\u22CF","cwconint":"\u2232","cwint":"\u2231","cylcty":"\u232D","dagger":"\u2020","Dagger":"\u2021","daleth":"\u2138","darr":"\u2193","Darr":"\u21A1","dArr":"\u21D3","dash":"\u2010","Dashv":"\u2AE4","dashv":"\u22A3","dbkarow":"\u290F","dblac":"\u02DD","Dcaron":"\u010E","dcaron":"\u010F","Dcy":"\u0414","dcy":"\u0434","ddagger":"\u2021","ddarr":"\u21CA","DD":"\u2145","dd":"\u2146","DDotrahd":"\u2911","ddotseq":"\u2A77","deg":"\u00B0","Del":"\u2207","Delta":"\u0394","delta":"\u03B4","demptyv":"\u29B1","dfisht":"\u297F","Dfr":"\uD835\uDD07","dfr":"\uD835\uDD21","dHar":"\u2965","dharl":"\u21C3","dharr":"\u21C2","DiacriticalAcute":"\u00B4","DiacriticalDot":"\u02D9","DiacriticalDoubleAcute":"\u02DD","DiacriticalGrave":"`","DiacriticalTilde":"\u02DC","diam":"\u22C4","diamond":"\u22C4","Diamond":"\u22C4","diamondsuit":"\u2666","diams":"\u2666","die":"\u00A8","DifferentialD":"\u2146","digamma":"\u03DD","disin":"\u22F2","div":"\u00F7","divide":"\u00F7","divideontimes":"\u22C7","divonx":"\u22C7","DJcy":"\u0402","djcy":"\u0452","dlcorn":"\u231E","dlcrop":"\u230D","dollar":"$","Dopf":"\uD835\uDD3B","dopf":"\uD835\uDD55","Dot":"\u00A8","dot":"\u02D9","DotDot":"\u20DC","doteq":"\u2250","doteqdot":"\u2251","DotEqual":"\u2250","dotminus":"\u2238","dotplus":"\u2214","dotsquare":"\u22A1","doublebarwedge":"\u2306","DoubleContourIntegral":"\u222F","DoubleDot":"\u00A8","DoubleDownArrow":"\u21D3","DoubleLeftArrow":"\u21D0","DoubleLeftRightArrow":"\u21D4","DoubleLeftTee":"\u2AE4","DoubleLongLeftArrow":"\u27F8","DoubleLongLeftRightArrow":"\u27FA","DoubleLongRightArrow":"\u27F9","DoubleRightArrow":"\u21D2","DoubleRightTee":"\u22A8","DoubleUpArrow":"\u21D1","DoubleUpDownArrow":"\u21D5","DoubleVerticalBar":"\u2225","DownArrowBar":"\u2913","downarrow":"\u2193","DownArrow":"\u2193","Downarrow":"\u21D3","DownArrowUpArrow":"\u21F5","DownBreve":"\u0311","downdownarrows":"\u21CA","downharpoonleft":"\u21C3","downharpoonright":"\u21C2","DownLeftRightVector":"\u2950","DownLeftTeeVector":"\u295E","DownLeftVectorBar":"\u2956","DownLeftVector":"\u21BD","DownRightTeeVector":"\u295F","DownRightVectorBar":"\u2957","DownRightVector":"\u21C1","DownTeeArrow":"\u21A7","DownTee":"\u22A4","drbkarow":"\u2910","drcorn":"\u231F","drcrop":"\u230C","Dscr":"\uD835\uDC9F","dscr":"\uD835\uDCB9","DScy":"\u0405","dscy":"\u0455","dsol":"\u29F6","Dstrok":"\u0110","dstrok":"\u0111","dtdot":"\u22F1","dtri":"\u25BF","dtrif":"\u25BE","duarr":"\u21F5","duhar":"\u296F","dwangle":"\u29A6","DZcy":"\u040F","dzcy":"\u045F","dzigrarr":"\u27FF","Eacute":"\u00C9","eacute":"\u00E9","easter":"\u2A6E","Ecaron":"\u011A","ecaron":"\u011B","Ecirc":"\u00CA","ecirc":"\u00EA","ecir":"\u2256","ecolon":"\u2255","Ecy":"\u042D","ecy":"\u044D","eDDot":"\u2A77","Edot":"\u0116","edot":"\u0117","eDot":"\u2251","ee":"\u2147","efDot":"\u2252","Efr":"\uD835\uDD08","efr":"\uD835\uDD22","eg":"\u2A9A","Egrave":"\u00C8","egrave":"\u00E8","egs":"\u2A96","egsdot":"\u2A98","el":"\u2A99","Element":"\u2208","elinters":"\u23E7","ell":"\u2113","els":"\u2A95","elsdot":"\u2A97","Emacr":"\u0112","emacr":"\u0113","empty":"\u2205","emptyset":"\u2205","EmptySmallSquare":"\u25FB","emptyv":"\u2205","EmptyVerySmallSquare":"\u25AB","emsp13":"\u2004","emsp14":"\u2005","emsp":"\u2003","ENG":"\u014A","eng":"\u014B","ensp":"\u2002","Eogon":"\u0118","eogon":"\u0119","Eopf":"\uD835\uDD3C","eopf":"\uD835\uDD56","epar":"\u22D5","eparsl":"\u29E3","eplus":"\u2A71","epsi":"\u03B5","Epsilon":"\u0395","epsilon":"\u03B5","epsiv":"\u03F5","eqcirc":"\u2256","eqcolon":"\u2255","eqsim":"\u2242","eqslantgtr":"\u2A96","eqslantless":"\u2A95","Equal":"\u2A75","equals":"=","EqualTilde":"\u2242","equest":"\u225F","Equilibrium":"\u21CC","equiv":"\u2261","equivDD":"\u2A78","eqvparsl":"\u29E5","erarr":"\u2971","erDot":"\u2253","escr":"\u212F","Escr":"\u2130","esdot":"\u2250","Esim":"\u2A73","esim":"\u2242","Eta":"\u0397","eta":"\u03B7","ETH":"\u00D0","eth":"\u00F0","Euml":"\u00CB","euml":"\u00EB","euro":"\u20AC","excl":"!","exist":"\u2203","Exists":"\u2203","expectation":"\u2130","exponentiale":"\u2147","ExponentialE":"\u2147","fallingdotseq":"\u2252","Fcy":"\u0424","fcy":"\u0444","female":"\u2640","ffilig":"\uFB03","fflig":"\uFB00","ffllig":"\uFB04","Ffr":"\uD835\uDD09","ffr":"\uD835\uDD23","filig":"\uFB01","FilledSmallSquare":"\u25FC","FilledVerySmallSquare":"\u25AA","fjlig":"fj","flat":"\u266D","fllig":"\uFB02","fltns":"\u25B1","fnof":"\u0192","Fopf":"\uD835\uDD3D","fopf":"\uD835\uDD57","forall":"\u2200","ForAll":"\u2200","fork":"\u22D4","forkv":"\u2AD9","Fouriertrf":"\u2131","fpartint":"\u2A0D","frac12":"\u00BD","frac13":"\u2153","frac14":"\u00BC","frac15":"\u2155","frac16":"\u2159","frac18":"\u215B","frac23":"\u2154","frac25":"\u2156","frac34":"\u00BE","frac35":"\u2157","frac38":"\u215C","frac45":"\u2158","frac56":"\u215A","frac58":"\u215D","frac78":"\u215E","frasl":"\u2044","frown":"\u2322","fscr":"\uD835\uDCBB","Fscr":"\u2131","gacute":"\u01F5","Gamma":"\u0393","gamma":"\u03B3","Gammad":"\u03DC","gammad":"\u03DD","gap":"\u2A86","Gbreve":"\u011E","gbreve":"\u011F","Gcedil":"\u0122","Gcirc":"\u011C","gcirc":"\u011D","Gcy":"\u0413","gcy":"\u0433","Gdot":"\u0120","gdot":"\u0121","ge":"\u2265","gE":"\u2267","gEl":"\u2A8C","gel":"\u22DB","geq":"\u2265","geqq":"\u2267","geqslant":"\u2A7E","gescc":"\u2AA9","ges":"\u2A7E","gesdot":"\u2A80","gesdoto":"\u2A82","gesdotol":"\u2A84","gesl":"\u22DB\uFE00","gesles":"\u2A94","Gfr":"\uD835\uDD0A","gfr":"\uD835\uDD24","gg":"\u226B","Gg":"\u22D9","ggg":"\u22D9","gimel":"\u2137","GJcy":"\u0403","gjcy":"\u0453","gla":"\u2AA5","gl":"\u2277","glE":"\u2A92","glj":"\u2AA4","gnap":"\u2A8A","gnapprox":"\u2A8A","gne":"\u2A88","gnE":"\u2269","gneq":"\u2A88","gneqq":"\u2269","gnsim":"\u22E7","Gopf":"\uD835\uDD3E","gopf":"\uD835\uDD58","grave":"`","GreaterEqual":"\u2265","GreaterEqualLess":"\u22DB","GreaterFullEqual":"\u2267","GreaterGreater":"\u2AA2","GreaterLess":"\u2277","GreaterSlantEqual":"\u2A7E","GreaterTilde":"\u2273","Gscr":"\uD835\uDCA2","gscr":"\u210A","gsim":"\u2273","gsime":"\u2A8E","gsiml":"\u2A90","gtcc":"\u2AA7","gtcir":"\u2A7A","gt":">","GT":">","Gt":"\u226B","gtdot":"\u22D7","gtlPar":"\u2995","gtquest":"\u2A7C","gtrapprox":"\u2A86","gtrarr":"\u2978","gtrdot":"\u22D7","gtreqless":"\u22DB","gtreqqless":"\u2A8C","gtrless":"\u2277","gtrsim":"\u2273","gvertneqq":"\u2269\uFE00","gvnE":"\u2269\uFE00","Hacek":"\u02C7","hairsp":"\u200A","half":"\u00BD","hamilt":"\u210B","HARDcy":"\u042A","hardcy":"\u044A","harrcir":"\u2948","harr":"\u2194","hArr":"\u21D4","harrw":"\u21AD","Hat":"^","hbar":"\u210F","Hcirc":"\u0124","hcirc":"\u0125","hearts":"\u2665","heartsuit":"\u2665","hellip":"\u2026","hercon":"\u22B9","hfr":"\uD835\uDD25","Hfr":"\u210C","HilbertSpace":"\u210B","hksearow":"\u2925","hkswarow":"\u2926","hoarr":"\u21FF","homtht":"\u223B","hookleftarrow":"\u21A9","hookrightarrow":"\u21AA","hopf":"\uD835\uDD59","Hopf":"\u210D","horbar":"\u2015","HorizontalLine":"\u2500","hscr":"\uD835\uDCBD","Hscr":"\u210B","hslash":"\u210F","Hstrok":"\u0126","hstrok":"\u0127","HumpDownHump":"\u224E","HumpEqual":"\u224F","hybull":"\u2043","hyphen":"\u2010","Iacute":"\u00CD","iacute":"\u00ED","ic":"\u2063","Icirc":"\u00CE","icirc":"\u00EE","Icy":"\u0418","icy":"\u0438","Idot":"\u0130","IEcy":"\u0415","iecy":"\u0435","iexcl":"\u00A1","iff":"\u21D4","ifr":"\uD835\uDD26","Ifr":"\u2111","Igrave":"\u00CC","igrave":"\u00EC","ii":"\u2148","iiiint":"\u2A0C","iiint":"\u222D","iinfin":"\u29DC","iiota":"\u2129","IJlig":"\u0132","ijlig":"\u0133","Imacr":"\u012A","imacr":"\u012B","image":"\u2111","ImaginaryI":"\u2148","imagline":"\u2110","imagpart":"\u2111","imath":"\u0131","Im":"\u2111","imof":"\u22B7","imped":"\u01B5","Implies":"\u21D2","incare":"\u2105","in":"\u2208","infin":"\u221E","infintie":"\u29DD","inodot":"\u0131","intcal":"\u22BA","int":"\u222B","Int":"\u222C","integers":"\u2124","Integral":"\u222B","intercal":"\u22BA","Intersection":"\u22C2","intlarhk":"\u2A17","intprod":"\u2A3C","InvisibleComma":"\u2063","InvisibleTimes":"\u2062","IOcy":"\u0401","iocy":"\u0451","Iogon":"\u012E","iogon":"\u012F","Iopf":"\uD835\uDD40","iopf":"\uD835\uDD5A","Iota":"\u0399","iota":"\u03B9","iprod":"\u2A3C","iquest":"\u00BF","iscr":"\uD835\uDCBE","Iscr":"\u2110","isin":"\u2208","isindot":"\u22F5","isinE":"\u22F9","isins":"\u22F4","isinsv":"\u22F3","isinv":"\u2208","it":"\u2062","Itilde":"\u0128","itilde":"\u0129","Iukcy":"\u0406","iukcy":"\u0456","Iuml":"\u00CF","iuml":"\u00EF","Jcirc":"\u0134","jcirc":"\u0135","Jcy":"\u0419","jcy":"\u0439","Jfr":"\uD835\uDD0D","jfr":"\uD835\uDD27","jmath":"\u0237","Jopf":"\uD835\uDD41","jopf":"\uD835\uDD5B","Jscr":"\uD835\uDCA5","jscr":"\uD835\uDCBF","Jsercy":"\u0408","jsercy":"\u0458","Jukcy":"\u0404","jukcy":"\u0454","Kappa":"\u039A","kappa":"\u03BA","kappav":"\u03F0","Kcedil":"\u0136","kcedil":"\u0137","Kcy":"\u041A","kcy":"\u043A","Kfr":"\uD835\uDD0E","kfr":"\uD835\uDD28","kgreen":"\u0138","KHcy":"\u0425","khcy":"\u0445","KJcy":"\u040C","kjcy":"\u045C","Kopf":"\uD835\uDD42","kopf":"\uD835\uDD5C","Kscr":"\uD835\uDCA6","kscr":"\uD835\uDCC0","lAarr":"\u21DA","Lacute":"\u0139","lacute":"\u013A","laemptyv":"\u29B4","lagran":"\u2112","Lambda":"\u039B","lambda":"\u03BB","lang":"\u27E8","Lang":"\u27EA","langd":"\u2991","langle":"\u27E8","lap":"\u2A85","Laplacetrf":"\u2112","laquo":"\u00AB","larrb":"\u21E4","larrbfs":"\u291F","larr":"\u2190","Larr":"\u219E","lArr":"\u21D0","larrfs":"\u291D","larrhk":"\u21A9","larrlp":"\u21AB","larrpl":"\u2939","larrsim":"\u2973","larrtl":"\u21A2","latail":"\u2919","lAtail":"\u291B","lat":"\u2AAB","late":"\u2AAD","lates":"\u2AAD\uFE00","lbarr":"\u290C","lBarr":"\u290E","lbbrk":"\u2772","lbrace":"{","lbrack":"[","lbrke":"\u298B","lbrksld":"\u298F","lbrkslu":"\u298D","Lcaron":"\u013D","lcaron":"\u013E","Lcedil":"\u013B","lcedil":"\u013C","lceil":"\u2308","lcub":"{","Lcy":"\u041B","lcy":"\u043B","ldca":"\u2936","ldquo":"\u201C","ldquor":"\u201E","ldrdhar":"\u2967","ldrushar":"\u294B","ldsh":"\u21B2","le":"\u2264","lE":"\u2266","LeftAngleBracket":"\u27E8","LeftArrowBar":"\u21E4","leftarrow":"\u2190","LeftArrow":"\u2190","Leftarrow":"\u21D0","LeftArrowRightArrow":"\u21C6","leftarrowtail":"\u21A2","LeftCeiling":"\u2308","LeftDoubleBracket":"\u27E6","LeftDownTeeVector":"\u2961","LeftDownVectorBar":"\u2959","LeftDownVector":"\u21C3","LeftFloor":"\u230A","leftharpoondown":"\u21BD","leftharpoonup":"\u21BC","leftleftarrows":"\u21C7","leftrightarrow":"\u2194","LeftRightArrow":"\u2194","Leftrightarrow":"\u21D4","leftrightarrows":"\u21C6","leftrightharpoons":"\u21CB","leftrightsquigarrow":"\u21AD","LeftRightVector":"\u294E","LeftTeeArrow":"\u21A4","LeftTee":"\u22A3","LeftTeeVector":"\u295A","leftthreetimes":"\u22CB","LeftTriangleBar":"\u29CF","LeftTriangle":"\u22B2","LeftTriangleEqual":"\u22B4","LeftUpDownVector":"\u2951","LeftUpTeeVector":"\u2960","LeftUpVectorBar":"\u2958","LeftUpVector":"\u21BF","LeftVectorBar":"\u2952","LeftVector":"\u21BC","lEg":"\u2A8B","leg":"\u22DA","leq":"\u2264","leqq":"\u2266","leqslant":"\u2A7D","lescc":"\u2AA8","les":"\u2A7D","lesdot":"\u2A7F","lesdoto":"\u2A81","lesdotor":"\u2A83","lesg":"\u22DA\uFE00","lesges":"\u2A93","lessapprox":"\u2A85","lessdot":"\u22D6","lesseqgtr":"\u22DA","lesseqqgtr":"\u2A8B","LessEqualGreater":"\u22DA","LessFullEqual":"\u2266","LessGreater":"\u2276","lessgtr":"\u2276","LessLess":"\u2AA1","lesssim":"\u2272","LessSlantEqual":"\u2A7D","LessTilde":"\u2272","lfisht":"\u297C","lfloor":"\u230A","Lfr":"\uD835\uDD0F","lfr":"\uD835\uDD29","lg":"\u2276","lgE":"\u2A91","lHar":"\u2962","lhard":"\u21BD","lharu":"\u21BC","lharul":"\u296A","lhblk":"\u2584","LJcy":"\u0409","ljcy":"\u0459","llarr":"\u21C7","ll":"\u226A","Ll":"\u22D8","llcorner":"\u231E","Lleftarrow":"\u21DA","llhard":"\u296B","lltri":"\u25FA","Lmidot":"\u013F","lmidot":"\u0140","lmoustache":"\u23B0","lmoust":"\u23B0","lnap":"\u2A89","lnapprox":"\u2A89","lne":"\u2A87","lnE":"\u2268","lneq":"\u2A87","lneqq":"\u2268","lnsim":"\u22E6","loang":"\u27EC","loarr":"\u21FD","lobrk":"\u27E6","longleftarrow":"\u27F5","LongLeftArrow":"\u27F5","Longleftarrow":"\u27F8","longleftrightarrow":"\u27F7","LongLeftRightArrow":"\u27F7","Longleftrightarrow":"\u27FA","longmapsto":"\u27FC","longrightarrow":"\u27F6","LongRightArrow":"\u27F6","Longrightarrow":"\u27F9","looparrowleft":"\u21AB","looparrowright":"\u21AC","lopar":"\u2985","Lopf":"\uD835\uDD43","lopf":"\uD835\uDD5D","loplus":"\u2A2D","lotimes":"\u2A34","lowast":"\u2217","lowbar":"_","LowerLeftArrow":"\u2199","LowerRightArrow":"\u2198","loz":"\u25CA","lozenge":"\u25CA","lozf":"\u29EB","lpar":"(","lparlt":"\u2993","lrarr":"\u21C6","lrcorner":"\u231F","lrhar":"\u21CB","lrhard":"\u296D","lrm":"\u200E","lrtri":"\u22BF","lsaquo":"\u2039","lscr":"\uD835\uDCC1","Lscr":"\u2112","lsh":"\u21B0","Lsh":"\u21B0","lsim":"\u2272","lsime":"\u2A8D","lsimg":"\u2A8F","lsqb":"[","lsquo":"\u2018","lsquor":"\u201A","Lstrok":"\u0141","lstrok":"\u0142","ltcc":"\u2AA6","ltcir":"\u2A79","lt":"<","LT":"<","Lt":"\u226A","ltdot":"\u22D6","lthree":"\u22CB","ltimes":"\u22C9","ltlarr":"\u2976","ltquest":"\u2A7B","ltri":"\u25C3","ltrie":"\u22B4","ltrif":"\u25C2","ltrPar":"\u2996","lurdshar":"\u294A","luruhar":"\u2966","lvertneqq":"\u2268\uFE00","lvnE":"\u2268\uFE00","macr":"\u00AF","male":"\u2642","malt":"\u2720","maltese":"\u2720","Map":"\u2905","map":"\u21A6","mapsto":"\u21A6","mapstodown":"\u21A7","mapstoleft":"\u21A4","mapstoup":"\u21A5","marker":"\u25AE","mcomma":"\u2A29","Mcy":"\u041C","mcy":"\u043C","mdash":"\u2014","mDDot":"\u223A","measuredangle":"\u2221","MediumSpace":"\u205F","Mellintrf":"\u2133","Mfr":"\uD835\uDD10","mfr":"\uD835\uDD2A","mho":"\u2127","micro":"\u00B5","midast":"*","midcir":"\u2AF0","mid":"\u2223","middot":"\u00B7","minusb":"\u229F","minus":"\u2212","minusd":"\u2238","minusdu":"\u2A2A","MinusPlus":"\u2213","mlcp":"\u2ADB","mldr":"\u2026","mnplus":"\u2213","models":"\u22A7","Mopf":"\uD835\uDD44","mopf":"\uD835\uDD5E","mp":"\u2213","mscr":"\uD835\uDCC2","Mscr":"\u2133","mstpos":"\u223E","Mu":"\u039C","mu":"\u03BC","multimap":"\u22B8","mumap":"\u22B8","nabla":"\u2207","Nacute":"\u0143","nacute":"\u0144","nang":"\u2220\u20D2","nap":"\u2249","napE":"\u2A70\u0338","napid":"\u224B\u0338","napos":"\u0149","napprox":"\u2249","natural":"\u266E","naturals":"\u2115","natur":"\u266E","nbsp":"\u00A0","nbump":"\u224E\u0338","nbumpe":"\u224F\u0338","ncap":"\u2A43","Ncaron":"\u0147","ncaron":"\u0148","Ncedil":"\u0145","ncedil":"\u0146","ncong":"\u2247","ncongdot":"\u2A6D\u0338","ncup":"\u2A42","Ncy":"\u041D","ncy":"\u043D","ndash":"\u2013","nearhk":"\u2924","nearr":"\u2197","neArr":"\u21D7","nearrow":"\u2197","ne":"\u2260","nedot":"\u2250\u0338","NegativeMediumSpace":"\u200B","NegativeThickSpace":"\u200B","NegativeThinSpace":"\u200B","NegativeVeryThinSpace":"\u200B","nequiv":"\u2262","nesear":"\u2928","nesim":"\u2242\u0338","NestedGreaterGreater":"\u226B","NestedLessLess":"\u226A","NewLine":"\n","nexist":"\u2204","nexists":"\u2204","Nfr":"\uD835\uDD11","nfr":"\uD835\uDD2B","ngE":"\u2267\u0338","nge":"\u2271","ngeq":"\u2271","ngeqq":"\u2267\u0338","ngeqslant":"\u2A7E\u0338","nges":"\u2A7E\u0338","nGg":"\u22D9\u0338","ngsim":"\u2275","nGt":"\u226B\u20D2","ngt":"\u226F","ngtr":"\u226F","nGtv":"\u226B\u0338","nharr":"\u21AE","nhArr":"\u21CE","nhpar":"\u2AF2","ni":"\u220B","nis":"\u22FC","nisd":"\u22FA","niv":"\u220B","NJcy":"\u040A","njcy":"\u045A","nlarr":"\u219A","nlArr":"\u21CD","nldr":"\u2025","nlE":"\u2266\u0338","nle":"\u2270","nleftarrow":"\u219A","nLeftarrow":"\u21CD","nleftrightarrow":"\u21AE","nLeftrightarrow":"\u21CE","nleq":"\u2270","nleqq":"\u2266\u0338","nleqslant":"\u2A7D\u0338","nles":"\u2A7D\u0338","nless":"\u226E","nLl":"\u22D8\u0338","nlsim":"\u2274","nLt":"\u226A\u20D2","nlt":"\u226E","nltri":"\u22EA","nltrie":"\u22EC","nLtv":"\u226A\u0338","nmid":"\u2224","NoBreak":"\u2060","NonBreakingSpace":"\u00A0","nopf":"\uD835\uDD5F","Nopf":"\u2115","Not":"\u2AEC","not":"\u00AC","NotCongruent":"\u2262","NotCupCap":"\u226D","NotDoubleVerticalBar":"\u2226","NotElement":"\u2209","NotEqual":"\u2260","NotEqualTilde":"\u2242\u0338","NotExists":"\u2204","NotGreater":"\u226F","NotGreaterEqual":"\u2271","NotGreaterFullEqual":"\u2267\u0338","NotGreaterGreater":"\u226B\u0338","NotGreaterLess":"\u2279","NotGreaterSlantEqual":"\u2A7E\u0338","NotGreaterTilde":"\u2275","NotHumpDownHump":"\u224E\u0338","NotHumpEqual":"\u224F\u0338","notin":"\u2209","notindot":"\u22F5\u0338","notinE":"\u22F9\u0338","notinva":"\u2209","notinvb":"\u22F7","notinvc":"\u22F6","NotLeftTriangleBar":"\u29CF\u0338","NotLeftTriangle":"\u22EA","NotLeftTriangleEqual":"\u22EC","NotLess":"\u226E","NotLessEqual":"\u2270","NotLessGreater":"\u2278","NotLessLess":"\u226A\u0338","NotLessSlantEqual":"\u2A7D\u0338","NotLessTilde":"\u2274","NotNestedGreaterGreater":"\u2AA2\u0338","NotNestedLessLess":"\u2AA1\u0338","notni":"\u220C","notniva":"\u220C","notnivb":"\u22FE","notnivc":"\u22FD","NotPrecedes":"\u2280","NotPrecedesEqual":"\u2AAF\u0338","NotPrecedesSlantEqual":"\u22E0","NotReverseElement":"\u220C","NotRightTriangleBar":"\u29D0\u0338","NotRightTriangle":"\u22EB","NotRightTriangleEqual":"\u22ED","NotSquareSubset":"\u228F\u0338","NotSquareSubsetEqual":"\u22E2","NotSquareSuperset":"\u2290\u0338","NotSquareSupersetEqual":"\u22E3","NotSubset":"\u2282\u20D2","NotSubsetEqual":"\u2288","NotSucceeds":"\u2281","NotSucceedsEqual":"\u2AB0\u0338","NotSucceedsSlantEqual":"\u22E1","NotSucceedsTilde":"\u227F\u0338","NotSuperset":"\u2283\u20D2","NotSupersetEqual":"\u2289","NotTilde":"\u2241","NotTildeEqual":"\u2244","NotTildeFullEqual":"\u2247","NotTildeTilde":"\u2249","NotVerticalBar":"\u2224","nparallel":"\u2226","npar":"\u2226","nparsl":"\u2AFD\u20E5","npart":"\u2202\u0338","npolint":"\u2A14","npr":"\u2280","nprcue":"\u22E0","nprec":"\u2280","npreceq":"\u2AAF\u0338","npre":"\u2AAF\u0338","nrarrc":"\u2933\u0338","nrarr":"\u219B","nrArr":"\u21CF","nrarrw":"\u219D\u0338","nrightarrow":"\u219B","nRightarrow":"\u21CF","nrtri":"\u22EB","nrtrie":"\u22ED","nsc":"\u2281","nsccue":"\u22E1","nsce":"\u2AB0\u0338","Nscr":"\uD835\uDCA9","nscr":"\uD835\uDCC3","nshortmid":"\u2224","nshortparallel":"\u2226","nsim":"\u2241","nsime":"\u2244","nsimeq":"\u2244","nsmid":"\u2224","nspar":"\u2226","nsqsube":"\u22E2","nsqsupe":"\u22E3","nsub":"\u2284","nsubE":"\u2AC5\u0338","nsube":"\u2288","nsubset":"\u2282\u20D2","nsubseteq":"\u2288","nsubseteqq":"\u2AC5\u0338","nsucc":"\u2281","nsucceq":"\u2AB0\u0338","nsup":"\u2285","nsupE":"\u2AC6\u0338","nsupe":"\u2289","nsupset":"\u2283\u20D2","nsupseteq":"\u2289","nsupseteqq":"\u2AC6\u0338","ntgl":"\u2279","Ntilde":"\u00D1","ntilde":"\u00F1","ntlg":"\u2278","ntriangleleft":"\u22EA","ntrianglelefteq":"\u22EC","ntriangleright":"\u22EB","ntrianglerighteq":"\u22ED","Nu":"\u039D","nu":"\u03BD","num":"#","numero":"\u2116","numsp":"\u2007","nvap":"\u224D\u20D2","nvdash":"\u22AC","nvDash":"\u22AD","nVdash":"\u22AE","nVDash":"\u22AF","nvge":"\u2265\u20D2","nvgt":">\u20D2","nvHarr":"\u2904","nvinfin":"\u29DE","nvlArr":"\u2902","nvle":"\u2264\u20D2","nvlt":"<\u20D2","nvltrie":"\u22B4\u20D2","nvrArr":"\u2903","nvrtrie":"\u22B5\u20D2","nvsim":"\u223C\u20D2","nwarhk":"\u2923","nwarr":"\u2196","nwArr":"\u21D6","nwarrow":"\u2196","nwnear":"\u2927","Oacute":"\u00D3","oacute":"\u00F3","oast":"\u229B","Ocirc":"\u00D4","ocirc":"\u00F4","ocir":"\u229A","Ocy":"\u041E","ocy":"\u043E","odash":"\u229D","Odblac":"\u0150","odblac":"\u0151","odiv":"\u2A38","odot":"\u2299","odsold":"\u29BC","OElig":"\u0152","oelig":"\u0153","ofcir":"\u29BF","Ofr":"\uD835\uDD12","ofr":"\uD835\uDD2C","ogon":"\u02DB","Ograve":"\u00D2","ograve":"\u00F2","ogt":"\u29C1","ohbar":"\u29B5","ohm":"\u03A9","oint":"\u222E","olarr":"\u21BA","olcir":"\u29BE","olcross":"\u29BB","oline":"\u203E","olt":"\u29C0","Omacr":"\u014C","omacr":"\u014D","Omega":"\u03A9","omega":"\u03C9","Omicron":"\u039F","omicron":"\u03BF","omid":"\u29B6","ominus":"\u2296","Oopf":"\uD835\uDD46","oopf":"\uD835\uDD60","opar":"\u29B7","OpenCurlyDoubleQuote":"\u201C","OpenCurlyQuote":"\u2018","operp":"\u29B9","oplus":"\u2295","orarr":"\u21BB","Or":"\u2A54","or":"\u2228","ord":"\u2A5D","order":"\u2134","orderof":"\u2134","ordf":"\u00AA","ordm":"\u00BA","origof":"\u22B6","oror":"\u2A56","orslope":"\u2A57","orv":"\u2A5B","oS":"\u24C8","Oscr":"\uD835\uDCAA","oscr":"\u2134","Oslash":"\u00D8","oslash":"\u00F8","osol":"\u2298","Otilde":"\u00D5","otilde":"\u00F5","otimesas":"\u2A36","Otimes":"\u2A37","otimes":"\u2297","Ouml":"\u00D6","ouml":"\u00F6","ovbar":"\u233D","OverBar":"\u203E","OverBrace":"\u23DE","OverBracket":"\u23B4","OverParenthesis":"\u23DC","para":"\u00B6","parallel":"\u2225","par":"\u2225","parsim":"\u2AF3","parsl":"\u2AFD","part":"\u2202","PartialD":"\u2202","Pcy":"\u041F","pcy":"\u043F","percnt":"%","period":".","permil":"\u2030","perp":"\u22A5","pertenk":"\u2031","Pfr":"\uD835\uDD13","pfr":"\uD835\uDD2D","Phi":"\u03A6","phi":"\u03C6","phiv":"\u03D5","phmmat":"\u2133","phone":"\u260E","Pi":"\u03A0","pi":"\u03C0","pitchfork":"\u22D4","piv":"\u03D6","planck":"\u210F","planckh":"\u210E","plankv":"\u210F","plusacir":"\u2A23","plusb":"\u229E","pluscir":"\u2A22","plus":"+","plusdo":"\u2214","plusdu":"\u2A25","pluse":"\u2A72","PlusMinus":"\u00B1","plusmn":"\u00B1","plussim":"\u2A26","plustwo":"\u2A27","pm":"\u00B1","Poincareplane":"\u210C","pointint":"\u2A15","popf":"\uD835\uDD61","Popf":"\u2119","pound":"\u00A3","prap":"\u2AB7","Pr":"\u2ABB","pr":"\u227A","prcue":"\u227C","precapprox":"\u2AB7","prec":"\u227A","preccurlyeq":"\u227C","Precedes":"\u227A","PrecedesEqual":"\u2AAF","PrecedesSlantEqual":"\u227C","PrecedesTilde":"\u227E","preceq":"\u2AAF","precnapprox":"\u2AB9","precneqq":"\u2AB5","precnsim":"\u22E8","pre":"\u2AAF","prE":"\u2AB3","precsim":"\u227E","prime":"\u2032","Prime":"\u2033","primes":"\u2119","prnap":"\u2AB9","prnE":"\u2AB5","prnsim":"\u22E8","prod":"\u220F","Product":"\u220F","profalar":"\u232E","profline":"\u2312","profsurf":"\u2313","prop":"\u221D","Proportional":"\u221D","Proportion":"\u2237","propto":"\u221D","prsim":"\u227E","prurel":"\u22B0","Pscr":"\uD835\uDCAB","pscr":"\uD835\uDCC5","Psi":"\u03A8","psi":"\u03C8","puncsp":"\u2008","Qfr":"\uD835\uDD14","qfr":"\uD835\uDD2E","qint":"\u2A0C","qopf":"\uD835\uDD62","Qopf":"\u211A","qprime":"\u2057","Qscr":"\uD835\uDCAC","qscr":"\uD835\uDCC6","quaternions":"\u210D","quatint":"\u2A16","quest":"?","questeq":"\u225F","quot":"\"","QUOT":"\"","rAarr":"\u21DB","race":"\u223D\u0331","Racute":"\u0154","racute":"\u0155","radic":"\u221A","raemptyv":"\u29B3","rang":"\u27E9","Rang":"\u27EB","rangd":"\u2992","range":"\u29A5","rangle":"\u27E9","raquo":"\u00BB","rarrap":"\u2975","rarrb":"\u21E5","rarrbfs":"\u2920","rarrc":"\u2933","rarr":"\u2192","Rarr":"\u21A0","rArr":"\u21D2","rarrfs":"\u291E","rarrhk":"\u21AA","rarrlp":"\u21AC","rarrpl":"\u2945","rarrsim":"\u2974","Rarrtl":"\u2916","rarrtl":"\u21A3","rarrw":"\u219D","ratail":"\u291A","rAtail":"\u291C","ratio":"\u2236","rationals":"\u211A","rbarr":"\u290D","rBarr":"\u290F","RBarr":"\u2910","rbbrk":"\u2773","rbrace":"}","rbrack":"]","rbrke":"\u298C","rbrksld":"\u298E","rbrkslu":"\u2990","Rcaron":"\u0158","rcaron":"\u0159","Rcedil":"\u0156","rcedil":"\u0157","rceil":"\u2309","rcub":"}","Rcy":"\u0420","rcy":"\u0440","rdca":"\u2937","rdldhar":"\u2969","rdquo":"\u201D","rdquor":"\u201D","rdsh":"\u21B3","real":"\u211C","realine":"\u211B","realpart":"\u211C","reals":"\u211D","Re":"\u211C","rect":"\u25AD","reg":"\u00AE","REG":"\u00AE","ReverseElement":"\u220B","ReverseEquilibrium":"\u21CB","ReverseUpEquilibrium":"\u296F","rfisht":"\u297D","rfloor":"\u230B","rfr":"\uD835\uDD2F","Rfr":"\u211C","rHar":"\u2964","rhard":"\u21C1","rharu":"\u21C0","rharul":"\u296C","Rho":"\u03A1","rho":"\u03C1","rhov":"\u03F1","RightAngleBracket":"\u27E9","RightArrowBar":"\u21E5","rightarrow":"\u2192","RightArrow":"\u2192","Rightarrow":"\u21D2","RightArrowLeftArrow":"\u21C4","rightarrowtail":"\u21A3","RightCeiling":"\u2309","RightDoubleBracket":"\u27E7","RightDownTeeVector":"\u295D","RightDownVectorBar":"\u2955","RightDownVector":"\u21C2","RightFloor":"\u230B","rightharpoondown":"\u21C1","rightharpoonup":"\u21C0","rightleftarrows":"\u21C4","rightleftharpoons":"\u21CC","rightrightarrows":"\u21C9","rightsquigarrow":"\u219D","RightTeeArrow":"\u21A6","RightTee":"\u22A2","RightTeeVector":"\u295B","rightthreetimes":"\u22CC","RightTriangleBar":"\u29D0","RightTriangle":"\u22B3","RightTriangleEqual":"\u22B5","RightUpDownVector":"\u294F","RightUpTeeVector":"\u295C","RightUpVectorBar":"\u2954","RightUpVector":"\u21BE","RightVectorBar":"\u2953","RightVector":"\u21C0","ring":"\u02DA","risingdotseq":"\u2253","rlarr":"\u21C4","rlhar":"\u21CC","rlm":"\u200F","rmoustache":"\u23B1","rmoust":"\u23B1","rnmid":"\u2AEE","roang":"\u27ED","roarr":"\u21FE","robrk":"\u27E7","ropar":"\u2986","ropf":"\uD835\uDD63","Ropf":"\u211D","roplus":"\u2A2E","rotimes":"\u2A35","RoundImplies":"\u2970","rpar":")","rpargt":"\u2994","rppolint":"\u2A12","rrarr":"\u21C9","Rrightarrow":"\u21DB","rsaquo":"\u203A","rscr":"\uD835\uDCC7","Rscr":"\u211B","rsh":"\u21B1","Rsh":"\u21B1","rsqb":"]","rsquo":"\u2019","rsquor":"\u2019","rthree":"\u22CC","rtimes":"\u22CA","rtri":"\u25B9","rtrie":"\u22B5","rtrif":"\u25B8","rtriltri":"\u29CE","RuleDelayed":"\u29F4","ruluhar":"\u2968","rx":"\u211E","Sacute":"\u015A","sacute":"\u015B","sbquo":"\u201A","scap":"\u2AB8","Scaron":"\u0160","scaron":"\u0161","Sc":"\u2ABC","sc":"\u227B","sccue":"\u227D","sce":"\u2AB0","scE":"\u2AB4","Scedil":"\u015E","scedil":"\u015F","Scirc":"\u015C","scirc":"\u015D","scnap":"\u2ABA","scnE":"\u2AB6","scnsim":"\u22E9","scpolint":"\u2A13","scsim":"\u227F","Scy":"\u0421","scy":"\u0441","sdotb":"\u22A1","sdot":"\u22C5","sdote":"\u2A66","searhk":"\u2925","searr":"\u2198","seArr":"\u21D8","searrow":"\u2198","sect":"\u00A7","semi":";","seswar":"\u2929","setminus":"\u2216","setmn":"\u2216","sext":"\u2736","Sfr":"\uD835\uDD16","sfr":"\uD835\uDD30","sfrown":"\u2322","sharp":"\u266F","SHCHcy":"\u0429","shchcy":"\u0449","SHcy":"\u0428","shcy":"\u0448","ShortDownArrow":"\u2193","ShortLeftArrow":"\u2190","shortmid":"\u2223","shortparallel":"\u2225","ShortRightArrow":"\u2192","ShortUpArrow":"\u2191","shy":"\u00AD","Sigma":"\u03A3","sigma":"\u03C3","sigmaf":"\u03C2","sigmav":"\u03C2","sim":"\u223C","simdot":"\u2A6A","sime":"\u2243","simeq":"\u2243","simg":"\u2A9E","simgE":"\u2AA0","siml":"\u2A9D","simlE":"\u2A9F","simne":"\u2246","simplus":"\u2A24","simrarr":"\u2972","slarr":"\u2190","SmallCircle":"\u2218","smallsetminus":"\u2216","smashp":"\u2A33","smeparsl":"\u29E4","smid":"\u2223","smile":"\u2323","smt":"\u2AAA","smte":"\u2AAC","smtes":"\u2AAC\uFE00","SOFTcy":"\u042C","softcy":"\u044C","solbar":"\u233F","solb":"\u29C4","sol":"/","Sopf":"\uD835\uDD4A","sopf":"\uD835\uDD64","spades":"\u2660","spadesuit":"\u2660","spar":"\u2225","sqcap":"\u2293","sqcaps":"\u2293\uFE00","sqcup":"\u2294","sqcups":"\u2294\uFE00","Sqrt":"\u221A","sqsub":"\u228F","sqsube":"\u2291","sqsubset":"\u228F","sqsubseteq":"\u2291","sqsup":"\u2290","sqsupe":"\u2292","sqsupset":"\u2290","sqsupseteq":"\u2292","square":"\u25A1","Square":"\u25A1","SquareIntersection":"\u2293","SquareSubset":"\u228F","SquareSubsetEqual":"\u2291","SquareSuperset":"\u2290","SquareSupersetEqual":"\u2292","SquareUnion":"\u2294","squarf":"\u25AA","squ":"\u25A1","squf":"\u25AA","srarr":"\u2192","Sscr":"\uD835\uDCAE","sscr":"\uD835\uDCC8","ssetmn":"\u2216","ssmile":"\u2323","sstarf":"\u22C6","Star":"\u22C6","star":"\u2606","starf":"\u2605","straightepsilon":"\u03F5","straightphi":"\u03D5","strns":"\u00AF","sub":"\u2282","Sub":"\u22D0","subdot":"\u2ABD","subE":"\u2AC5","sube":"\u2286","subedot":"\u2AC3","submult":"\u2AC1","subnE":"\u2ACB","subne":"\u228A","subplus":"\u2ABF","subrarr":"\u2979","subset":"\u2282","Subset":"\u22D0","subseteq":"\u2286","subseteqq":"\u2AC5","SubsetEqual":"\u2286","subsetneq":"\u228A","subsetneqq":"\u2ACB","subsim":"\u2AC7","subsub":"\u2AD5","subsup":"\u2AD3","succapprox":"\u2AB8","succ":"\u227B","succcurlyeq":"\u227D","Succeeds":"\u227B","SucceedsEqual":"\u2AB0","SucceedsSlantEqual":"\u227D","SucceedsTilde":"\u227F","succeq":"\u2AB0","succnapprox":"\u2ABA","succneqq":"\u2AB6","succnsim":"\u22E9","succsim":"\u227F","SuchThat":"\u220B","sum":"\u2211","Sum":"\u2211","sung":"\u266A","sup1":"\u00B9","sup2":"\u00B2","sup3":"\u00B3","sup":"\u2283","Sup":"\u22D1","supdot":"\u2ABE","supdsub":"\u2AD8","supE":"\u2AC6","supe":"\u2287","supedot":"\u2AC4","Superset":"\u2283","SupersetEqual":"\u2287","suphsol":"\u27C9","suphsub":"\u2AD7","suplarr":"\u297B","supmult":"\u2AC2","supnE":"\u2ACC","supne":"\u228B","supplus":"\u2AC0","supset":"\u2283","Supset":"\u22D1","supseteq":"\u2287","supseteqq":"\u2AC6","supsetneq":"\u228B","supsetneqq":"\u2ACC","supsim":"\u2AC8","supsub":"\u2AD4","supsup":"\u2AD6","swarhk":"\u2926","swarr":"\u2199","swArr":"\u21D9","swarrow":"\u2199","swnwar":"\u292A","szlig":"\u00DF","Tab":"\t","target":"\u2316","Tau":"\u03A4","tau":"\u03C4","tbrk":"\u23B4","Tcaron":"\u0164","tcaron":"\u0165","Tcedil":"\u0162","tcedil":"\u0163","Tcy":"\u0422","tcy":"\u0442","tdot":"\u20DB","telrec":"\u2315","Tfr":"\uD835\uDD17","tfr":"\uD835\uDD31","there4":"\u2234","therefore":"\u2234","Therefore":"\u2234","Theta":"\u0398","theta":"\u03B8","thetasym":"\u03D1","thetav":"\u03D1","thickapprox":"\u2248","thicksim":"\u223C","ThickSpace":"\u205F\u200A","ThinSpace":"\u2009","thinsp":"\u2009","thkap":"\u2248","thksim":"\u223C","THORN":"\u00DE","thorn":"\u00FE","tilde":"\u02DC","Tilde":"\u223C","TildeEqual":"\u2243","TildeFullEqual":"\u2245","TildeTilde":"\u2248","timesbar":"\u2A31","timesb":"\u22A0","times":"\u00D7","timesd":"\u2A30","tint":"\u222D","toea":"\u2928","topbot":"\u2336","topcir":"\u2AF1","top":"\u22A4","Topf":"\uD835\uDD4B","topf":"\uD835\uDD65","topfork":"\u2ADA","tosa":"\u2929","tprime":"\u2034","trade":"\u2122","TRADE":"\u2122","triangle":"\u25B5","triangledown":"\u25BF","triangleleft":"\u25C3","trianglelefteq":"\u22B4","triangleq":"\u225C","triangleright":"\u25B9","trianglerighteq":"\u22B5","tridot":"\u25EC","trie":"\u225C","triminus":"\u2A3A","TripleDot":"\u20DB","triplus":"\u2A39","trisb":"\u29CD","tritime":"\u2A3B","trpezium":"\u23E2","Tscr":"\uD835\uDCAF","tscr":"\uD835\uDCC9","TScy":"\u0426","tscy":"\u0446","TSHcy":"\u040B","tshcy":"\u045B","Tstrok":"\u0166","tstrok":"\u0167","twixt":"\u226C","twoheadleftarrow":"\u219E","twoheadrightarrow":"\u21A0","Uacute":"\u00DA","uacute":"\u00FA","uarr":"\u2191","Uarr":"\u219F","uArr":"\u21D1","Uarrocir":"\u2949","Ubrcy":"\u040E","ubrcy":"\u045E","Ubreve":"\u016C","ubreve":"\u016D","Ucirc":"\u00DB","ucirc":"\u00FB","Ucy":"\u0423","ucy":"\u0443","udarr":"\u21C5","Udblac":"\u0170","udblac":"\u0171","udhar":"\u296E","ufisht":"\u297E","Ufr":"\uD835\uDD18","ufr":"\uD835\uDD32","Ugrave":"\u00D9","ugrave":"\u00F9","uHar":"\u2963","uharl":"\u21BF","uharr":"\u21BE","uhblk":"\u2580","ulcorn":"\u231C","ulcorner":"\u231C","ulcrop":"\u230F","ultri":"\u25F8","Umacr":"\u016A","umacr":"\u016B","uml":"\u00A8","UnderBar":"_","UnderBrace":"\u23DF","UnderBracket":"\u23B5","UnderParenthesis":"\u23DD","Union":"\u22C3","UnionPlus":"\u228E","Uogon":"\u0172","uogon":"\u0173","Uopf":"\uD835\uDD4C","uopf":"\uD835\uDD66","UpArrowBar":"\u2912","uparrow":"\u2191","UpArrow":"\u2191","Uparrow":"\u21D1","UpArrowDownArrow":"\u21C5","updownarrow":"\u2195","UpDownArrow":"\u2195","Updownarrow":"\u21D5","UpEquilibrium":"\u296E","upharpoonleft":"\u21BF","upharpoonright":"\u21BE","uplus":"\u228E","UpperLeftArrow":"\u2196","UpperRightArrow":"\u2197","upsi":"\u03C5","Upsi":"\u03D2","upsih":"\u03D2","Upsilon":"\u03A5","upsilon":"\u03C5","UpTeeArrow":"\u21A5","UpTee":"\u22A5","upuparrows":"\u21C8","urcorn":"\u231D","urcorner":"\u231D","urcrop":"\u230E","Uring":"\u016E","uring":"\u016F","urtri":"\u25F9","Uscr":"\uD835\uDCB0","uscr":"\uD835\uDCCA","utdot":"\u22F0","Utilde":"\u0168","utilde":"\u0169","utri":"\u25B5","utrif":"\u25B4","uuarr":"\u21C8","Uuml":"\u00DC","uuml":"\u00FC","uwangle":"\u29A7","vangrt":"\u299C","varepsilon":"\u03F5","varkappa":"\u03F0","varnothing":"\u2205","varphi":"\u03D5","varpi":"\u03D6","varpropto":"\u221D","varr":"\u2195","vArr":"\u21D5","varrho":"\u03F1","varsigma":"\u03C2","varsubsetneq":"\u228A\uFE00","varsubsetneqq":"\u2ACB\uFE00","varsupsetneq":"\u228B\uFE00","varsupsetneqq":"\u2ACC\uFE00","vartheta":"\u03D1","vartriangleleft":"\u22B2","vartriangleright":"\u22B3","vBar":"\u2AE8","Vbar":"\u2AEB","vBarv":"\u2AE9","Vcy":"\u0412","vcy":"\u0432","vdash":"\u22A2","vDash":"\u22A8","Vdash":"\u22A9","VDash":"\u22AB","Vdashl":"\u2AE6","veebar":"\u22BB","vee":"\u2228","Vee":"\u22C1","veeeq":"\u225A","vellip":"\u22EE","verbar":"|","Verbar":"\u2016","vert":"|","Vert":"\u2016","VerticalBar":"\u2223","VerticalLine":"|","VerticalSeparator":"\u2758","VerticalTilde":"\u2240","VeryThinSpace":"\u200A","Vfr":"\uD835\uDD19","vfr":"\uD835\uDD33","vltri":"\u22B2","vnsub":"\u2282\u20D2","vnsup":"\u2283\u20D2","Vopf":"\uD835\uDD4D","vopf":"\uD835\uDD67","vprop":"\u221D","vrtri":"\u22B3","Vscr":"\uD835\uDCB1","vscr":"\uD835\uDCCB","vsubnE":"\u2ACB\uFE00","vsubne":"\u228A\uFE00","vsupnE":"\u2ACC\uFE00","vsupne":"\u228B\uFE00","Vvdash":"\u22AA","vzigzag":"\u299A","Wcirc":"\u0174","wcirc":"\u0175","wedbar":"\u2A5F","wedge":"\u2227","Wedge":"\u22C0","wedgeq":"\u2259","weierp":"\u2118","Wfr":"\uD835\uDD1A","wfr":"\uD835\uDD34","Wopf":"\uD835\uDD4E","wopf":"\uD835\uDD68","wp":"\u2118","wr":"\u2240","wreath":"\u2240","Wscr":"\uD835\uDCB2","wscr":"\uD835\uDCCC","xcap":"\u22C2","xcirc":"\u25EF","xcup":"\u22C3","xdtri":"\u25BD","Xfr":"\uD835\uDD1B","xfr":"\uD835\uDD35","xharr":"\u27F7","xhArr":"\u27FA","Xi":"\u039E","xi":"\u03BE","xlarr":"\u27F5","xlArr":"\u27F8","xmap":"\u27FC","xnis":"\u22FB","xodot":"\u2A00","Xopf":"\uD835\uDD4F","xopf":"\uD835\uDD69","xoplus":"\u2A01","xotime":"\u2A02","xrarr":"\u27F6","xrArr":"\u27F9","Xscr":"\uD835\uDCB3","xscr":"\uD835\uDCCD","xsqcup":"\u2A06","xuplus":"\u2A04","xutri":"\u25B3","xvee":"\u22C1","xwedge":"\u22C0","Yacute":"\u00DD","yacute":"\u00FD","YAcy":"\u042F","yacy":"\u044F","Ycirc":"\u0176","ycirc":"\u0177","Ycy":"\u042B","ycy":"\u044B","yen":"\u00A5","Yfr":"\uD835\uDD1C","yfr":"\uD835\uDD36","YIcy":"\u0407","yicy":"\u0457","Yopf":"\uD835\uDD50","yopf":"\uD835\uDD6A","Yscr":"\uD835\uDCB4","yscr":"\uD835\uDCCE","YUcy":"\u042E","yucy":"\u044E","yuml":"\u00FF","Yuml":"\u0178","Zacute":"\u0179","zacute":"\u017A","Zcaron":"\u017D","zcaron":"\u017E","Zcy":"\u0417","zcy":"\u0437","Zdot":"\u017B","zdot":"\u017C","zeetrf":"\u2128","ZeroWidthSpace":"\u200B","Zeta":"\u0396","zeta":"\u03B6","zfr":"\uD835\uDD37","Zfr":"\u2128","ZHcy":"\u0416","zhcy":"\u0436","zigrarr":"\u21DD","zopf":"\uD835\uDD6B","Zopf":"\u2124","Zscr":"\uD835\uDCB5","zscr":"\uD835\uDCCF","zwj":"\u200D","zwnj":"\u200C"}
-},{}],22:[function(require,module,exports){
-'use strict';
+},{}],21:[function(require,module,exports){
+var isFunction = require('is-function')
 
-var isCallable = require('is-callable');
+module.exports = forEach
 
-var toStr = Object.prototype.toString;
-var hasOwnProperty = Object.prototype.hasOwnProperty;
+var toString = Object.prototype.toString
+var hasOwnProperty = Object.prototype.hasOwnProperty
 
-var forEachArray = function forEachArray(array, iterator, receiver) {
+function forEach(list, iterator, context) {
+    if (!isFunction(iterator)) {
+        throw new TypeError('iterator must be a function')
+    }
+
+    if (arguments.length < 3) {
+        context = this
+    }
+    
+    if (toString.call(list) === '[object Array]')
+        forEachArray(list, iterator, context)
+    else if (typeof list === 'string')
+        forEachString(list, iterator, context)
+    else
+        forEachObject(list, iterator, context)
+}
+
+function forEachArray(array, iterator, context) {
     for (var i = 0, len = array.length; i < len; i++) {
         if (hasOwnProperty.call(array, i)) {
-            if (receiver == null) {
-                iterator(array[i], i, array);
-            } else {
-                iterator.call(receiver, array[i], i, array);
-            }
+            iterator.call(context, array[i], i, array)
         }
     }
-};
+}
 
-var forEachString = function forEachString(string, iterator, receiver) {
+function forEachString(string, iterator, context) {
     for (var i = 0, len = string.length; i < len; i++) {
         // no such thing as a sparse string.
-        if (receiver == null) {
-            iterator(string.charAt(i), i, string);
-        } else {
-            iterator.call(receiver, string.charAt(i), i, string);
-        }
+        iterator.call(context, string.charAt(i), i, string)
     }
-};
+}
 
-var forEachObject = function forEachObject(object, iterator, receiver) {
+function forEachObject(object, iterator, context) {
     for (var k in object) {
         if (hasOwnProperty.call(object, k)) {
-            if (receiver == null) {
-                iterator(object[k], k, object);
-            } else {
-                iterator.call(receiver, object[k], k, object);
-            }
+            iterator.call(context, object[k], k, object)
         }
     }
-};
+}
 
-var forEach = function forEach(list, iterator, thisArg) {
-    if (!isCallable(iterator)) {
-        throw new TypeError('iterator must be a function');
-    }
-
-    var receiver;
-    if (arguments.length >= 3) {
-        receiver = thisArg;
-    }
-
-    if (toStr.call(list) === '[object Array]') {
-        forEachArray(list, iterator, receiver);
-    } else if (typeof list === 'string') {
-        forEachString(list, iterator, receiver);
-    } else {
-        forEachObject(list, iterator, receiver);
-    }
-};
-
-module.exports = forEach;
-
-},{"is-callable":63}],23:[function(require,module,exports){
+},{"is-function":48}],22:[function(require,module,exports){
 'use strict';
 
 function fuzzysearch (needle, haystack) {
@@ -1970,7 +1903,7 @@ function fuzzysearch (needle, haystack) {
 
 module.exports = fuzzysearch;
 
-},{}],24:[function(require,module,exports){
+},{}],23:[function(require,module,exports){
 (function (global){
 var win;
 
@@ -1987,7 +1920,7 @@ if (typeof window !== "undefined") {
 module.exports = win;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],25:[function(require,module,exports){
+},{}],24:[function(require,module,exports){
 'use strict';
 
 function pad (hash, len) {
@@ -2047,7 +1980,7 @@ function sum (o) {
 
 module.exports = sum;
 
-},{}],26:[function(require,module,exports){
+},{}],25:[function(require,module,exports){
 var Highlight = function() {
 
   /* Utility functions */
@@ -2726,7 +2659,7 @@ var Highlight = function() {
   };
 };
 module.exports = Highlight;
-},{}],27:[function(require,module,exports){
+},{}],26:[function(require,module,exports){
 var Highlight = require('./highlight');
 var hljs = new Highlight();
 hljs.registerLanguage('bash', require('./languages/bash.js'));
@@ -2738,7 +2671,7 @@ hljs.registerLanguage('http', require('./languages/http.js'));
 hljs.registerLanguage('ini', require('./languages/ini.js'));
 hljs.registerLanguage('json', require('./languages/json.js'));
 module.exports = hljs;
-},{"./highlight":26,"./languages/bash.js":28,"./languages/css.js":29,"./languages/http.js":30,"./languages/ini.js":31,"./languages/javascript.js":32,"./languages/json.js":33,"./languages/markdown.js":34,"./languages/xml.js":35}],28:[function(require,module,exports){
+},{"./highlight":25,"./languages/bash.js":27,"./languages/css.js":28,"./languages/http.js":29,"./languages/ini.js":30,"./languages/javascript.js":31,"./languages/json.js":32,"./languages/markdown.js":33,"./languages/xml.js":34}],27:[function(require,module,exports){
 module.exports = function(hljs) {
   var VAR = {
     className: 'variable',
@@ -2800,7 +2733,7 @@ module.exports = function(hljs) {
     ]
   };
 };
-},{}],29:[function(require,module,exports){
+},{}],28:[function(require,module,exports){
 module.exports = function(hljs) {
   var IDENT_RE = '[a-zA-Z-][a-zA-Z0-9_-]*';
   var FUNCTION = {
@@ -2902,7 +2835,7 @@ module.exports = function(hljs) {
     ]
   };
 };
-},{}],30:[function(require,module,exports){
+},{}],29:[function(require,module,exports){
 module.exports = function(hljs) {
   return {
     illegal: '\\S',
@@ -2936,7 +2869,7 @@ module.exports = function(hljs) {
     ]
   };
 };
-},{}],31:[function(require,module,exports){
+},{}],30:[function(require,module,exports){
 module.exports = function(hljs) {
   return {
     case_insensitive: true,
@@ -2966,7 +2899,7 @@ module.exports = function(hljs) {
     ]
   };
 };
-},{}],32:[function(require,module,exports){
+},{}],31:[function(require,module,exports){
 module.exports = function(hljs) {
   return {
     aliases: ['js'],
@@ -3037,7 +2970,7 @@ module.exports = function(hljs) {
     ]
   };
 };
-},{}],33:[function(require,module,exports){
+},{}],32:[function(require,module,exports){
 module.exports = function(hljs) {
   var LITERALS = {literal: 'true false null'};
   var TYPES = [
@@ -3075,7 +3008,7 @@ module.exports = function(hljs) {
     illegal: '\\S'
   };
 };
-},{}],34:[function(require,module,exports){
+},{}],33:[function(require,module,exports){
 module.exports = function(hljs) {
   return {
     contains: [
@@ -3176,7 +3109,7 @@ module.exports = function(hljs) {
     ]
   };
 };
-},{}],35:[function(require,module,exports){
+},{}],34:[function(require,module,exports){
 module.exports = function(hljs) {
   var XML_IDENT_RE = '[A-Za-z0-9\\._:-]+';
   var PHP = {
@@ -3280,7 +3213,7 @@ module.exports = function(hljs) {
     ]
   };
 };
-},{}],36:[function(require,module,exports){
+},{}],35:[function(require,module,exports){
 // http://highlightjs.readthedocs.org/en/latest/css-classes-reference.html
 
 module.exports = [
@@ -3408,7 +3341,7 @@ module.exports = [
   'yardoctag'
 ]
 
-},{}],37:[function(require,module,exports){
+},{}],36:[function(require,module,exports){
 'use strict';
 
 var _hashSum = require('hash-sum');
@@ -4478,110 +4411,721 @@ function isEditable(el) {
 
 module.exports = horsey;
 
-},{"bullseye":38,"contra/emitter":14,"crossvent":44,"fuzzysearch":23,"hash-sum":25,"lodash/debounce":46,"sektor":138,"sell":147}],38:[function(require,module,exports){
+},{"bullseye":6,"contra/emitter":14,"crossvent":37,"fuzzysearch":22,"hash-sum":24,"lodash/debounce":53,"sektor":133,"sell":142}],37:[function(require,module,exports){
+arguments[4][10][0].apply(exports,arguments)
+},{"./eventmap":38,"custom-event":17,"dup":10}],38:[function(require,module,exports){
+arguments[4][5][0].apply(exports,arguments)
+},{"dup":5}],39:[function(require,module,exports){
 'use strict';
 
-var crossvent = require('crossvent');
-var throttle = require('./throttle');
-var tailormade = require('./tailormade');
+var toMap = require('./toMap');
+var uris = ['background', 'base', 'cite', 'href', 'longdesc', 'src', 'usemap'];
 
-function bullseye (el, target, options) {
-  var o = options;
-  var domTarget = target && target.tagName;
+module.exports = {
+  uris: toMap(uris) // attributes that have an href and hence need to be sanitized
+};
 
-  if (!domTarget && arguments.length === 2) {
-    o = target;
-  }
-  if (!domTarget) {
-    target = el;
-  }
-  if (!o) { o = {}; }
+},{"./toMap":47}],40:[function(require,module,exports){
+'use strict';
 
-  var destroyed = false;
-  var throttledWrite = throttle(write, 30);
-  var tailorOptions = { update: o.autoupdateToCaret !== false && update };
-  var tailor = o.caret && tailormade(target, tailorOptions);
+var defaults = {
+  allowedAttributes: {
+    a: ['href', 'name', 'target', 'title', 'aria-label'],
+    iframe: ['allowfullscreen', 'frameborder', 'src'],
+    img: ['src', 'alt', 'title', 'aria-label']
+  },
+  allowedClasses: {},
+  allowedSchemes: ['http', 'https', 'mailto'],
+  allowedTags: [
+    'a', 'abbr', 'article', 'b', 'blockquote', 'br', 'caption', 'code', 'del', 'details', 'div', 'em',
+    'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'img', 'ins', 'kbd', 'li', 'main', 'mark',
+    'ol', 'p', 'pre', 'section', 'span', 'strike', 'strong', 'sub', 'summary', 'sup', 'table',
+    'tbody', 'td', 'th', 'thead', 'tr', 'ul'
+  ],
+  filter: null
+};
 
-  write();
+module.exports = defaults;
 
-  if (o.tracking !== false) {
-    crossvent.add(window, 'resize', throttledWrite);
-  }
+},{}],41:[function(require,module,exports){
+'use strict';
 
-  return {
-    read: readNull,
-    refresh: write,
-    destroy: destroy,
-    sleep: sleep
+var toMap = require('./toMap');
+var voids = ['area', 'br', 'col', 'hr', 'img', 'wbr', 'input', 'base', 'basefont', 'link', 'meta'];
+
+module.exports = {
+  voids: toMap(voids)
+};
+
+},{"./toMap":47}],42:[function(require,module,exports){
+'use strict';
+
+var he = require('he');
+var assign = require('assignment');
+var parser = require('./parser');
+var sanitizer = require('./sanitizer');
+var defaults = require('./defaults');
+
+function insane (html, options, strict) {
+  var buffer = [];
+  var configuration = strict === true ? options : assign({}, defaults, options);
+  var handler = sanitizer(buffer, configuration);
+
+  parser(html, handler);
+
+  return buffer.join('');
+}
+
+insane.defaults = defaults;
+module.exports = insane;
+
+},{"./defaults":40,"./parser":44,"./sanitizer":45,"assignment":1,"he":46}],43:[function(require,module,exports){
+'use strict';
+
+module.exports = function lowercase (string) {
+  return typeof string === 'string' ? string.toLowerCase() : string;
+};
+
+},{}],44:[function(require,module,exports){
+'use strict';
+
+var he = require('he');
+var lowercase = require('./lowercase');
+var attributes = require('./attributes');
+var elements = require('./elements');
+var rstart = /^<\s*([\w:-]+)((?:\s+[\w:-]+(?:\s*=\s*(?:(?:"[^"]*")|(?:'[^']*')|[^>\s]+))?)*)\s*(\/?)\s*>/;
+var rend = /^<\s*\/\s*([\w:-]+)[^>]*>/;
+var rattrs = /([\w:-]+)(?:\s*=\s*(?:(?:"((?:[^"])*)")|(?:'((?:[^'])*)')|([^>\s]+)))?/g;
+var rtag = /^</;
+var rtagend = /^<\s*\//;
+
+function createStack () {
+  var stack = [];
+  stack.lastItem = function lastItem () {
+    return stack[stack.length - 1];
   };
+  return stack;
+}
 
-  function sleep () {
-    tailorOptions.sleeping = true;
+function parser (html, handler) {
+  var stack = createStack();
+  var last = html;
+  var chars;
+
+  while (html) {
+    parsePart();
+  }
+  parseEndTag(); // clean up any remaining tags
+
+  function parsePart () {
+    chars = true;
+    parseTag();
+
+    var same = html === last;
+    last = html;
+
+    if (same) { // discard, because it's invalid
+      html = '';
+    }
   }
 
-  function readNull () { return read(); }
-
-  function read (readings) {
-    var bounds = target.getBoundingClientRect();
-    var scrollTop = document.body.scrollTop || document.documentElement.scrollTop;
-    if (tailor) {
-      readings = tailor.read();
-      return {
-        x: (readings.absolute ? 0 : bounds.left) + readings.x,
-        y: (readings.absolute ? 0 : bounds.top) + scrollTop + readings.y + 20
-      };
+  function parseTag () {
+    if (html.substr(0, 4) === '<!--') { // comments
+      parseComment();
+    } else if (rtagend.test(html)) {
+      parseEdge(rend, parseEndTag);
+    } else if (rtag.test(html)) {
+      parseEdge(rstart, parseStartTag);
     }
-    return {
-      x: bounds.left,
-      y: bounds.top + scrollTop
-    };
+    parseTagDecode();
   }
 
-  function update (readings) {
-    write(readings);
+  function parseEdge (regex, parser) {
+    var match = html.match(regex);
+    if (match) {
+      html = html.substring(match[0].length);
+      match[0].replace(regex, parser);
+      chars = false;
+    }
   }
 
-  function write (readings) {
-    if (destroyed) {
-      throw new Error('Bullseye can\'t refresh after being destroyed. Create another instance instead.');
+  function parseComment () {
+    var index = html.indexOf('-->');
+    if (index >= 0) {
+      if (handler.comment) {
+        handler.comment(html.substring(4, index));
+      }
+      html = html.substring(index + 3);
+      chars = false;
     }
-    if (tailor && !readings) {
-      tailorOptions.sleeping = false;
-      tailor.refresh(); return;
-    }
-    var p = read(readings);
-    if (!tailor && target !== el) {
-      p.y += target.offsetHeight;
-    }
-    var context = o.context;
-    el.style.left = p.x + 'px';
-    el.style.top = (context ? context.offsetHeight : p.y) + 'px';
   }
 
-  function destroy () {
-    if (tailor) { tailor.destroy(); }
-    crossvent.remove(window, 'resize', throttledWrite);
-    destroyed = true;
+  function parseTagDecode () {
+    if (!chars) {
+      return;
+    }
+    var text;
+    var index = html.indexOf('<');
+    if (index >= 0) {
+      text = html.substring(0, index);
+      html = html.substring(index);
+    } else {
+      text = html;
+      html = '';
+    }
+    if (handler.chars) {
+      handler.chars(text);
+    }
+  }
+
+  function parseStartTag (tag, tagName, rest, unary) {
+    var attrs = {};
+    var low = lowercase(tagName);
+    var u = elements.voids[low] || !!unary;
+
+    rest.replace(rattrs, attrReplacer);
+
+    if (!u) {
+      stack.push(low);
+    }
+    if (handler.start) {
+      handler.start(low, attrs, u);
+    }
+
+    function attrReplacer (match, name, doubleQuotedValue, singleQuotedValue, unquotedValue) {
+      if (doubleQuotedValue === void 0 && singleQuotedValue === void 0 && unquotedValue === void 0) {
+        attrs[name] = void 0; // attribute is like <button disabled></button>
+      } else {
+        attrs[name] = he.decode(doubleQuotedValue || singleQuotedValue || unquotedValue || '');
+      }
+    }
+  }
+
+  function parseEndTag (tag, tagName) {
+    var i;
+    var pos = 0;
+    var low = lowercase(tagName);
+    if (low) {
+      for (pos = stack.length - 1; pos >= 0; pos--) {
+        if (stack[pos] === low) {
+          break; // find the closest opened tag of the same type
+        }
+      }
+    }
+    if (pos >= 0) {
+      for (i = stack.length - 1; i >= pos; i--) {
+        if (handler.end) { // close all the open elements, up the stack
+          handler.end(stack[i]);
+        }
+      }
+      stack.length = pos;
+    }
   }
 }
 
-module.exports = bullseye;
+module.exports = parser;
 
-},{"./tailormade":42,"./throttle":43,"crossvent":39}],39:[function(require,module,exports){
-arguments[4][10][0].apply(exports,arguments)
-},{"./eventmap":40,"custom-event":41,"dup":10}],40:[function(require,module,exports){
-arguments[4][5][0].apply(exports,arguments)
-},{"dup":5}],41:[function(require,module,exports){
-arguments[4][15][0].apply(exports,arguments)
-},{"dup":15}],42:[function(require,module,exports){
-arguments[4][7][0].apply(exports,arguments)
-},{"./throttle":43,"crossvent":39,"dup":7,"seleccion":145,"sell":147}],43:[function(require,module,exports){
-arguments[4][8][0].apply(exports,arguments)
-},{"dup":8}],44:[function(require,module,exports){
-arguments[4][10][0].apply(exports,arguments)
-},{"./eventmap":45,"custom-event":18,"dup":10}],45:[function(require,module,exports){
-arguments[4][5][0].apply(exports,arguments)
-},{"dup":5}],46:[function(require,module,exports){
+},{"./attributes":39,"./elements":41,"./lowercase":43,"he":46}],45:[function(require,module,exports){
+'use strict';
+
+var he = require('he');
+var lowercase = require('./lowercase');
+var attributes = require('./attributes');
+
+function sanitizer (buffer, options) {
+  var last;
+  var context;
+  var o = options || {};
+
+  reset();
+
+  return {
+    start: start,
+    end: end,
+    chars: chars
+  };
+
+  function out (value) {
+    buffer.push(value);
+  }
+
+  function start (tag, attrs, unary) {
+    var low = lowercase(tag);
+
+    if (context.ignoring) {
+      ignore(low); return;
+    }
+    if ((o.allowedTags || []).indexOf(low) === -1) {
+      ignore(low); return;
+    }
+    if (o.filter && !o.filter({ tag: low, attrs: attrs })) {
+      ignore(low); return;
+    }
+
+    out('<');
+    out(low);
+    Object.keys(attrs).forEach(parse);
+    out(unary ? '/>' : '>');
+
+    function parse (key) {
+      var value = attrs[key];
+      var classesOk = (o.allowedClasses || {})[low] || [];
+      var attrsOk = (o.allowedAttributes || {})[low] || [];
+      var valid;
+      var lkey = lowercase(key);
+      if (lkey === 'class' && attrsOk.indexOf(lkey) === -1) {
+        value = value.split(' ').filter(isValidClass).join(' ').trim();
+        valid = value.length;
+      } else {
+        valid = attrsOk.indexOf(lkey) !== -1 && (attributes.uris[lkey] !== true || testUrl(value));
+      }
+      if (valid) {
+        out(' ');
+        out(key);
+        if (typeof value === 'string') {
+          out('="');
+          out(he.encode(value));
+          out('"');
+        }
+      }
+      function isValidClass (className) {
+        return classesOk && classesOk.indexOf(className) !== -1;
+      }
+    }
+  }
+
+  function end (tag) {
+    var low = lowercase(tag);
+    var allowed = (o.allowedTags || []).indexOf(low) !== -1;
+    if (allowed) {
+      if (context.ignoring === false) {
+        out('</');
+        out(low);
+        out('>');
+      } else {
+        unignore(low);
+      }
+    } else {
+      unignore(low);
+    }
+  }
+
+  function testUrl (text) {
+    var start = text[0];
+    if (start === '#' || start === '/') {
+      return true;
+    }
+    var colon = text.indexOf(':');
+    if (colon === -1) {
+      return true;
+    }
+    var questionmark = text.indexOf('?');
+    if (questionmark !== -1 && colon > questionmark) {
+      return true;
+    }
+    var hash = text.indexOf('#');
+    if (hash !== -1 && colon > hash) {
+      return true;
+    }
+    return o.allowedSchemes.some(matches);
+
+    function matches (scheme) {
+      return text.indexOf(scheme + ':') === 0;
+    }
+  }
+
+  function chars (text) {
+    if (context.ignoring === false) {
+      out(o.transformText ? o.transformText(text) : text);
+    }
+  }
+
+  function ignore (tag) {
+    if (context.ignoring === false) {
+      context = { ignoring: tag, depth: 1 };
+    } else if (context.ignoring === tag) {
+      context.depth++;
+    }
+  }
+
+  function unignore (tag) {
+    if (context.ignoring === tag) {
+      if (--context.depth <= 0) {
+        reset();
+      }
+    }
+  }
+
+  function reset () {
+    context = { ignoring: false, depth: 0 };
+  }
+}
+
+module.exports = sanitizer;
+
+},{"./attributes":39,"./lowercase":43,"he":46}],46:[function(require,module,exports){
+'use strict';
+
+var escapes = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;'
+};
+var unescapes = {
+  '&amp;': '&',
+  '&lt;': '<',
+  '&gt;': '>',
+  '&quot;': '"',
+  '&#39;': "'"
+};
+var rescaped = /(&amp;|&lt;|&gt;|&quot;|&#39;)/g;
+var runescaped = /[&<>"']/g;
+
+function escapeHtmlChar (match) {
+  return escapes[match];
+}
+function unescapeHtmlChar (match) {
+  return unescapes[match];
+}
+
+function escapeHtml (text) {
+  return text == null ? '' : String(text).replace(runescaped, escapeHtmlChar);
+}
+
+function unescapeHtml (html) {
+  return html == null ? '' : String(html).replace(rescaped, unescapeHtmlChar);
+}
+
+escapeHtml.options = unescapeHtml.options = {};
+
+module.exports = {
+  encode: escapeHtml,
+  escape: escapeHtml,
+  decode: unescapeHtml,
+  unescape: unescapeHtml,
+  version: '1.0.0-browser'
+};
+
+},{}],47:[function(require,module,exports){
+'use strict';
+
+function toMap (list) {
+  return list.reduce(asKey, {});
+}
+
+function asKey (accumulator, item) {
+  accumulator[item] = true;
+  return accumulator;
+}
+
+module.exports = toMap;
+
+},{}],48:[function(require,module,exports){
+module.exports = isFunction
+
+var toString = Object.prototype.toString
+
+function isFunction (fn) {
+  var string = toString.call(fn)
+  return string === '[object Function]' ||
+    (typeof fn === 'function' && string !== '[object RegExp]') ||
+    (typeof window !== 'undefined' &&
+     // IE8 and below
+     (fn === window.setTimeout ||
+      fn === window.alert ||
+      fn === window.confirm ||
+      fn === window.prompt))
+};
+
+},{}],49:[function(require,module,exports){
+'use strict';
+
+var sektor = require('sektor');
+var crossvent = require('crossvent');
+var rspaces = /\s+/g;
+var keymap = {
+  13: 'enter',
+  27: 'esc',
+  32: 'space'
+};
+var handlers = {};
+
+crossvent.add(window, 'keydown', keydown);
+
+function clear (context) {
+  if (context) {
+    if (context in handlers) {
+      handlers[context] = {};
+    }
+  } else {
+    handlers = {};
+  }
+}
+
+function switchboard (then, combo, options, fn) {
+  if (fn === void 0) {
+    fn = options;
+    options = {};
+  }
+
+  var context = options.context || 'defaults';
+
+  if (!fn) {
+    return;
+  }
+
+  if (handlers[context] === void 0) {
+    handlers[context] = {};
+  }
+
+  combo.toLowerCase().split(rspaces).forEach(item);
+
+  function item (keys) {
+    var c = keys.trim();
+    if (c.length === 0) {
+      return;
+    }
+    then(handlers[context], c, options, fn);
+  }
+}
+
+function on (combo, options, fn) {
+  switchboard(add, combo, options, fn);
+
+  function add (area, key, options, fn) {
+    var handler = {
+      handle: fn,
+      filter: options.filter
+    };
+    if (area[key]) {
+      area[key].push(handler);
+    } else {
+      area[key] = [handler];
+    }
+  }
+}
+
+function off (combo, options, fn) {
+  switchboard(rm, combo, options, fn);
+
+  function rm (area, key, options, fn) {
+    if (area[key]) {
+      area[key] = area[key].filter(matching);
+    }
+
+    function matching (handler) {
+      return handler.handle === fn && handler.filter === options.filter;
+    }
+  }
+}
+
+function getKeyCode (e) {
+  return e.which || e.keyCode || e.charCode;
+}
+
+function keydown (e) {
+  var code = getKeyCode(e);
+  var key = keymap[code] || String.fromCharCode(code);
+  if (key) {
+    handle(key, e);
+  }
+}
+
+function parseKeyCombo (key, e) {
+  var combo = [key];
+  if (e.shiftKey) {
+    combo.unshift('shift');
+  }
+  if (e.altKey) {
+    combo.unshift('alt');
+  }
+  if (e.ctrlKey ^ e.metaKey) {
+    combo.unshift('cmd');
+  }
+  return combo.join('+').toLowerCase();
+}
+
+function handle (key, e) {
+  var combo = parseKeyCombo(key, e);
+  var context;
+  for (context in handlers) {
+    if (handlers[context][combo]) {
+      handlers[context][combo].forEach(exec);
+    }
+  }
+
+  function filtered (handler) {
+    var filter = handler.filter;
+    if (!filter) {
+      return;
+    }
+
+    var el = e.target;
+    var selector = typeof filter === 'string';
+    if (selector) {
+      return sektor.matchesSelector(el, filter) === false;
+    }
+    while (el.parentElement && el !== filter) {
+      el = el.parentElement;
+    }
+    return el !== filter;
+  }
+
+  function exec (handler) {
+    if (filtered(handler)) {
+      return;
+    }
+    handler.handle(e);
+  }
+}
+
+module.exports = {
+  on: on,
+  off: off,
+  clear: clear,
+  handlers: handlers
+};
+
+},{"crossvent":15,"sektor":133}],50:[function(require,module,exports){
+(function (global){
+'use strict';
+
+var stub = require('./stub');
+var tracking = require('./tracking');
+var ls = 'localStorage' in global && global.localStorage ? global.localStorage : stub;
+
+function accessor (key, value) {
+  if (arguments.length === 1) {
+    return get(key);
+  }
+  return set(key, value);
+}
+
+function get (key) {
+  return JSON.parse(ls.getItem(key));
+}
+
+function set (key, value) {
+  try {
+    ls.setItem(key, JSON.stringify(value));
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function remove (key) {
+  return ls.removeItem(key);
+}
+
+function clear () {
+  return ls.clear();
+}
+
+accessor.set = set;
+accessor.get = get;
+accessor.remove = remove;
+accessor.clear = clear;
+accessor.on = tracking.on;
+accessor.off = tracking.off;
+
+module.exports = accessor;
+
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{"./stub":51,"./tracking":52}],51:[function(require,module,exports){
+'use strict';
+
+var ms = {};
+
+function getItem (key) {
+  return key in ms ? ms[key] : null;
+}
+
+function setItem (key, value) {
+  ms[key] = value;
+  return true;
+}
+
+function removeItem (key) {
+  var found = key in ms;
+  if (found) {
+    return delete ms[key];
+  }
+  return false;
+}
+
+function clear () {
+  ms = {};
+  return true;
+}
+
+module.exports = {
+  getItem: getItem,
+  setItem: setItem,
+  removeItem: removeItem,
+  clear: clear
+};
+
+},{}],52:[function(require,module,exports){
+(function (global){
+'use strict';
+
+var listeners = {};
+var listening = false;
+
+function listen () {
+  if (global.addEventListener) {
+    global.addEventListener('storage', change, false);
+  } else if (global.attachEvent) {
+    global.attachEvent('onstorage', change);
+  } else {
+    global.onstorage = change;
+  }
+}
+
+function change (e) {
+  if (!e) {
+    e = global.event;
+  }
+  var all = listeners[e.key];
+  if (all) {
+    all.forEach(fire);
+  }
+
+  function fire (listener) {
+    listener(JSON.parse(e.newValue), JSON.parse(e.oldValue), e.url || e.uri);
+  }
+}
+
+function on (key, fn) {
+  if (listeners[key]) {
+    listeners[key].push(fn);
+  } else {
+    listeners[key] = [fn];
+  }
+  if (listening === false) {
+    listen();
+  }
+}
+
+function off (key, fn) {
+  var ns = listeners[key];
+  if (ns.length > 1) {
+    ns.splice(ns.indexOf(fn), 1);
+  } else {
+    listeners[key] = [];
+  }
+}
+
+module.exports = {
+  on: on,
+  off: off
+};
+
+}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
+},{}],53:[function(require,module,exports){
 var isObject = require('./isObject'),
     now = require('./now'),
     toNumber = require('./toNumber');
@@ -4764,7 +5308,7 @@ function debounce(func, wait, options) {
 
 module.exports = debounce;
 
-},{"./isObject":48,"./now":51,"./toNumber":52}],47:[function(require,module,exports){
+},{"./isObject":55,"./now":58,"./toNumber":59}],54:[function(require,module,exports){
 var isObject = require('./isObject');
 
 /** `Object#toString` result references. */
@@ -4809,7 +5353,7 @@ function isFunction(value) {
 
 module.exports = isFunction;
 
-},{"./isObject":48}],48:[function(require,module,exports){
+},{"./isObject":55}],55:[function(require,module,exports){
 /**
  * Checks if `value` is the
  * [language type](http://www.ecma-international.org/ecma-262/6.0/#sec-ecmascript-language-types)
@@ -4842,7 +5386,7 @@ function isObject(value) {
 
 module.exports = isObject;
 
-},{}],49:[function(require,module,exports){
+},{}],56:[function(require,module,exports){
 /**
  * Checks if `value` is object-like. A value is object-like if it's not `null`
  * and has a `typeof` result of "object".
@@ -4873,7 +5417,7 @@ function isObjectLike(value) {
 
 module.exports = isObjectLike;
 
-},{}],50:[function(require,module,exports){
+},{}],57:[function(require,module,exports){
 var isObjectLike = require('./isObjectLike');
 
 /** `Object#toString` result references. */
@@ -4914,7 +5458,7 @@ function isSymbol(value) {
 
 module.exports = isSymbol;
 
-},{"./isObjectLike":49}],51:[function(require,module,exports){
+},{"./isObjectLike":56}],58:[function(require,module,exports){
 /**
  * Gets the timestamp of the number of milliseconds that have elapsed since
  * the Unix epoch (1 January 1970 00:00:00 UTC).
@@ -4937,7 +5481,7 @@ function now() {
 
 module.exports = now;
 
-},{}],52:[function(require,module,exports){
+},{}],59:[function(require,module,exports){
 var isFunction = require('./isFunction'),
     isObject = require('./isObject'),
     isSymbol = require('./isSymbol');
@@ -5006,865 +5550,13 @@ function toNumber(value) {
 
 module.exports = toNumber;
 
-},{"./isFunction":47,"./isObject":48,"./isSymbol":50}],53:[function(require,module,exports){
-'use strict';
-
-var toMap = require('./toMap');
-var uris = ['background', 'base', 'cite', 'href', 'longdesc', 'src', 'usemap'];
-
-module.exports = {
-  uris: toMap(uris) // attributes that have an href and hence need to be sanitized
-};
-
-},{"./toMap":62}],54:[function(require,module,exports){
-'use strict';
-
-var defaults = {
-  allowedAttributes: {
-    a: ['href', 'name', 'target', 'title', 'aria-label'],
-    iframe: ['allowfullscreen', 'frameborder', 'src'],
-    img: ['src', 'alt', 'title', 'aria-label']
-  },
-  allowedClasses: {},
-  allowedSchemes: ['http', 'https', 'mailto'],
-  allowedTags: [
-    'a', 'abbr', 'article', 'b', 'blockquote', 'br', 'caption', 'code', 'del', 'details', 'div', 'em',
-    'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'hr', 'i', 'img', 'ins', 'kbd', 'li', 'main', 'mark',
-    'ol', 'p', 'pre', 'section', 'span', 'strike', 'strong', 'sub', 'summary', 'sup', 'table',
-    'tbody', 'td', 'th', 'thead', 'tr', 'ul'
-  ],
-  filter: null
-};
-
-module.exports = defaults;
-
-},{}],55:[function(require,module,exports){
-'use strict';
-
-var toMap = require('./toMap');
-var voids = ['area', 'br', 'col', 'hr', 'img', 'wbr', 'input', 'base', 'basefont', 'link', 'meta'];
-
-module.exports = {
-  voids: toMap(voids)
-};
-
-},{"./toMap":62}],56:[function(require,module,exports){
-'use strict';
-
-var he = require('he');
-var assign = require('assignment');
-var parser = require('./parser');
-var sanitizer = require('./sanitizer');
-var defaults = require('./defaults');
-
-function insane (html, options, strict) {
-  var buffer = [];
-  var configuration = strict === true ? options : assign({}, defaults, options);
-  var handler = sanitizer(buffer, configuration);
-
-  parser(html, handler);
-
-  return buffer.join('');
-}
-
-insane.defaults = defaults;
-module.exports = insane;
-
-},{"./defaults":54,"./parser":59,"./sanitizer":60,"assignment":58,"he":61}],57:[function(require,module,exports){
-'use strict';
-
-module.exports = function lowercase (string) {
-  return typeof string === 'string' ? string.toLowerCase() : string;
-};
-
-},{}],58:[function(require,module,exports){
-'use strict';
-
-function assignment (result) {
-  var stack = Array.prototype.slice.call(arguments, 1);
-  var item;
-  var key;
-  while (stack.length) {
-    item = stack.shift();
-    for (key in item) {
-      if (item.hasOwnProperty(key)) {
-        if (typeof result[key] === 'object' && result[key] && Object.prototype.toString.call(result[key]) !== '[object Array]') {
-          if (typeof item[key] === 'object' && item[key] !== null) {
-            result[key] = assignment({}, result[key], item[key]);
-          } else {
-            result[key] = item[key];
-          }
-        } else {
-          result[key] = item[key];
-        }
-      }
-    }
-  }
-  return result;
-}
-
-module.exports = assignment;
-
-},{}],59:[function(require,module,exports){
-'use strict';
-
-var he = require('he');
-var lowercase = require('./lowercase');
-var attributes = require('./attributes');
-var elements = require('./elements');
-var rstart = /^<\s*([\w:-]+)((?:\s+[\w:-]+(?:\s*=\s*(?:(?:"[^"]*")|(?:'[^']*')|[^>\s]+))?)*)\s*(\/?)\s*>/;
-var rend = /^<\s*\/\s*([\w:-]+)[^>]*>/;
-var rattrs = /([\w:-]+)(?:\s*=\s*(?:(?:"((?:[^"])*)")|(?:'((?:[^'])*)')|([^>\s]+)))?/g;
-var rtag = /^</;
-var rtagend = /^<\s*\//;
-
-function createStack () {
-  var stack = [];
-  stack.lastItem = function lastItem () {
-    return stack[stack.length - 1];
-  };
-  return stack;
-}
-
-function parser (html, handler) {
-  var stack = createStack();
-  var last = html;
-  var chars;
-
-  while (html) {
-    parsePart();
-  }
-  parseEndTag(); // clean up any remaining tags
-
-  function parsePart () {
-    chars = true;
-    parseTag();
-
-    var same = html === last;
-    last = html;
-
-    if (same) { // discard, because it's invalid
-      html = '';
-    }
-  }
-
-  function parseTag () {
-    if (html.substr(0, 4) === '<!--') { // comments
-      parseComment();
-    } else if (rtagend.test(html)) {
-      parseEdge(rend, parseEndTag);
-    } else if (rtag.test(html)) {
-      parseEdge(rstart, parseStartTag);
-    }
-    parseTagDecode();
-  }
-
-  function parseEdge (regex, parser) {
-    var match = html.match(regex);
-    if (match) {
-      html = html.substring(match[0].length);
-      match[0].replace(regex, parser);
-      chars = false;
-    }
-  }
-
-  function parseComment () {
-    var index = html.indexOf('-->');
-    if (index >= 0) {
-      if (handler.comment) {
-        handler.comment(html.substring(4, index));
-      }
-      html = html.substring(index + 3);
-      chars = false;
-    }
-  }
-
-  function parseTagDecode () {
-    if (!chars) {
-      return;
-    }
-    var text;
-    var index = html.indexOf('<');
-    if (index >= 0) {
-      text = html.substring(0, index);
-      html = html.substring(index);
-    } else {
-      text = html;
-      html = '';
-    }
-    if (handler.chars) {
-      handler.chars(text);
-    }
-  }
-
-  function parseStartTag (tag, tagName, rest, unary) {
-    var attrs = {};
-    var low = lowercase(tagName);
-    var u = elements.voids[low] || !!unary;
-
-    rest.replace(rattrs, attrReplacer);
-
-    if (!u) {
-      stack.push(low);
-    }
-    if (handler.start) {
-      handler.start(low, attrs, u);
-    }
-
-    function attrReplacer (match, name, doubleQuotedValue, singleQuotedValue, unquotedValue) {
-      if (doubleQuotedValue === void 0 && singleQuotedValue === void 0 && unquotedValue === void 0) {
-        attrs[name] = void 0; // attribute is like <button disabled></button>
-      } else {
-        attrs[name] = he.decode(doubleQuotedValue || singleQuotedValue || unquotedValue || '');
-      }
-    }
-  }
-
-  function parseEndTag (tag, tagName) {
-    var i;
-    var pos = 0;
-    var low = lowercase(tagName);
-    if (low) {
-      for (pos = stack.length - 1; pos >= 0; pos--) {
-        if (stack[pos] === low) {
-          break; // find the closest opened tag of the same type
-        }
-      }
-    }
-    if (pos >= 0) {
-      for (i = stack.length - 1; i >= pos; i--) {
-        if (handler.end) { // close all the open elements, up the stack
-          handler.end(stack[i]);
-        }
-      }
-      stack.length = pos;
-    }
-  }
-}
-
-module.exports = parser;
-
-},{"./attributes":53,"./elements":55,"./lowercase":57,"he":61}],60:[function(require,module,exports){
-'use strict';
-
-var he = require('he');
-var lowercase = require('./lowercase');
-var attributes = require('./attributes');
-
-function sanitizer (buffer, options) {
-  var last;
-  var context;
-  var o = options || {};
-
-  reset();
-
-  return {
-    start: start,
-    end: end,
-    chars: chars
-  };
-
-  function out (value) {
-    buffer.push(value);
-  }
-
-  function start (tag, attrs, unary) {
-    var low = lowercase(tag);
-
-    if (context.ignoring) {
-      ignore(low); return;
-    }
-    if ((o.allowedTags || []).indexOf(low) === -1) {
-      ignore(low); return;
-    }
-    if (o.filter && !o.filter({ tag: low, attrs: attrs })) {
-      ignore(low); return;
-    }
-
-    out('<');
-    out(low);
-    Object.keys(attrs).forEach(parse);
-    out(unary ? '/>' : '>');
-
-    function parse (key) {
-      var value = attrs[key];
-      var classesOk = (o.allowedClasses || {})[low] || [];
-      var attrsOk = (o.allowedAttributes || {})[low] || [];
-      var valid;
-      var lkey = lowercase(key);
-      if (lkey === 'class' && attrsOk.indexOf(lkey) === -1) {
-        value = value.split(' ').filter(isValidClass).join(' ').trim();
-        valid = value.length;
-      } else {
-        valid = attrsOk.indexOf(lkey) !== -1 && (attributes.uris[lkey] !== true || testUrl(value));
-      }
-      if (valid) {
-        out(' ');
-        out(key);
-        if (typeof value === 'string') {
-          out('="');
-          out(he.encode(value));
-          out('"');
-        }
-      }
-      function isValidClass (className) {
-        return classesOk && classesOk.indexOf(className) !== -1;
-      }
-    }
-  }
-
-  function end (tag) {
-    var low = lowercase(tag);
-    var allowed = (o.allowedTags || []).indexOf(low) !== -1;
-    if (allowed) {
-      if (context.ignoring === false) {
-        out('</');
-        out(low);
-        out('>');
-      } else {
-        unignore(low);
-      }
-    } else {
-      unignore(low);
-    }
-  }
-
-  function testUrl (text) {
-    var start = text[0];
-    if (start === '#' || start === '/') {
-      return true;
-    }
-    var colon = text.indexOf(':');
-    if (colon === -1) {
-      return true;
-    }
-    var questionmark = text.indexOf('?');
-    if (questionmark !== -1 && colon > questionmark) {
-      return true;
-    }
-    var hash = text.indexOf('#');
-    if (hash !== -1 && colon > hash) {
-      return true;
-    }
-    return o.allowedSchemes.some(matches);
-
-    function matches (scheme) {
-      return text.indexOf(scheme + ':') === 0;
-    }
-  }
-
-  function chars (text) {
-    if (context.ignoring === false) {
-      out(o.transformText ? o.transformText(text) : text);
-    }
-  }
-
-  function ignore (tag) {
-    if (context.ignoring === false) {
-      context = { ignoring: tag, depth: 1 };
-    } else if (context.ignoring === tag) {
-      context.depth++;
-    }
-  }
-
-  function unignore (tag) {
-    if (context.ignoring === tag) {
-      if (--context.depth <= 0) {
-        reset();
-      }
-    }
-  }
-
-  function reset () {
-    context = { ignoring: false, depth: 0 };
-  }
-}
-
-module.exports = sanitizer;
-
-},{"./attributes":53,"./lowercase":57,"he":61}],61:[function(require,module,exports){
-'use strict';
-
-var escapes = {
-  '&': '&amp;',
-  '<': '&lt;',
-  '>': '&gt;',
-  '"': '&quot;',
-  "'": '&#39;'
-};
-var unescapes = {
-  '&amp;': '&',
-  '&lt;': '<',
-  '&gt;': '>',
-  '&quot;': '"',
-  '&#39;': "'"
-};
-var rescaped = /(&amp;|&lt;|&gt;|&quot;|&#39;)/g;
-var runescaped = /[&<>"']/g;
-
-function escapeHtmlChar (match) {
-  return escapes[match];
-}
-function unescapeHtmlChar (match) {
-  return unescapes[match];
-}
-
-function escapeHtml (text) {
-  return text == null ? '' : String(text).replace(runescaped, escapeHtmlChar);
-}
-
-function unescapeHtml (html) {
-  return html == null ? '' : String(html).replace(rescaped, unescapeHtmlChar);
-}
-
-escapeHtml.options = unescapeHtml.options = {};
-
-module.exports = {
-  encode: escapeHtml,
-  escape: escapeHtml,
-  decode: unescapeHtml,
-  unescape: unescapeHtml,
-  version: '1.0.0-browser'
-};
-
-},{}],62:[function(require,module,exports){
-'use strict';
-
-function toMap (list) {
-  return list.reduce(asKey, {});
-}
-
-function asKey (accumulator, item) {
-  accumulator[item] = true;
-  return accumulator;
-}
-
-module.exports = toMap;
-
-},{}],63:[function(require,module,exports){
-'use strict';
-
-var fnToStr = Function.prototype.toString;
-
-var constructorRegex = /^\s*class\b/;
-var isES6ClassFn = function isES6ClassFunction(value) {
-	try {
-		var fnStr = fnToStr.call(value);
-		return constructorRegex.test(fnStr);
-	} catch (e) {
-		return false; // not a function
-	}
-};
-
-var tryFunctionObject = function tryFunctionToStr(value) {
-	try {
-		if (isES6ClassFn(value)) { return false; }
-		fnToStr.call(value);
-		return true;
-	} catch (e) {
-		return false;
-	}
-};
-var toStr = Object.prototype.toString;
-var fnClass = '[object Function]';
-var genClass = '[object GeneratorFunction]';
-var hasToStringTag = typeof Symbol === 'function' && typeof Symbol.toStringTag === 'symbol';
-
-module.exports = function isCallable(value) {
-	if (!value) { return false; }
-	if (typeof value !== 'function' && typeof value !== 'object') { return false; }
-	if (typeof value === 'function' && !value.prototype) { return true; }
-	if (hasToStringTag) { return tryFunctionObject(value); }
-	if (isES6ClassFn(value)) { return false; }
-	var strClass = toStr.call(value);
-	return strClass === fnClass || strClass === genClass;
-};
-
-},{}],64:[function(require,module,exports){
-module.exports = isFunction
-
-var toString = Object.prototype.toString
-
-function isFunction (fn) {
-  var string = toString.call(fn)
-  return string === '[object Function]' ||
-    (typeof fn === 'function' && string !== '[object RegExp]') ||
-    (typeof window !== 'undefined' &&
-     // IE8 and below
-     (fn === window.setTimeout ||
-      fn === window.alert ||
-      fn === window.confirm ||
-      fn === window.prompt))
-};
-
-},{}],65:[function(require,module,exports){
-'use strict';
-
-var sektor = require('sektor');
-var crossvent = require('crossvent');
-var rspaces = /\s+/g;
-var keymap = {
-  13: 'enter',
-  27: 'esc',
-  32: 'space'
-};
-var handlers = {};
-
-crossvent.add(window, 'keydown', keydown);
-
-function clear (context) {
-  if (context) {
-    if (context in handlers) {
-      handlers[context] = {};
-    }
-  } else {
-    handlers = {};
-  }
-}
-
-function switchboard (then, combo, options, fn) {
-  if (fn === void 0) {
-    fn = options;
-    options = {};
-  }
-
-  var context = options.context || 'defaults';
-
-  if (!fn) {
-    return;
-  }
-
-  if (handlers[context] === void 0) {
-    handlers[context] = {};
-  }
-
-  combo.toLowerCase().split(rspaces).forEach(item);
-
-  function item (keys) {
-    var c = keys.trim();
-    if (c.length === 0) {
-      return;
-    }
-    then(handlers[context], c, options, fn);
-  }
-}
-
-function on (combo, options, fn) {
-  switchboard(add, combo, options, fn);
-
-  function add (area, key, options, fn) {
-    var handler = {
-      handle: fn,
-      filter: options.filter
-    };
-    if (area[key]) {
-      area[key].push(handler);
-    } else {
-      area[key] = [handler];
-    }
-  }
-}
-
-function off (combo, options, fn) {
-  switchboard(rm, combo, options, fn);
-
-  function rm (area, key, options, fn) {
-    if (area[key]) {
-      area[key] = area[key].filter(matching);
-    }
-
-    function matching (handler) {
-      return handler.handle === fn && handler.filter === options.filter;
-    }
-  }
-}
-
-function getKeyCode (e) {
-  return e.which || e.keyCode || e.charCode;
-}
-
-function keydown (e) {
-  var code = getKeyCode(e);
-  var key = keymap[code] || String.fromCharCode(code);
-  if (key) {
-    handle(key, e);
-  }
-}
-
-function parseKeyCombo (key, e) {
-  var combo = [key];
-  if (e.shiftKey) {
-    combo.unshift('shift');
-  }
-  if (e.altKey) {
-    combo.unshift('alt');
-  }
-  if (e.ctrlKey ^ e.metaKey) {
-    combo.unshift('cmd');
-  }
-  return combo.join('+').toLowerCase();
-}
-
-function handle (key, e) {
-  var combo = parseKeyCombo(key, e);
-  var context;
-  for (context in handlers) {
-    if (handlers[context][combo]) {
-      handlers[context][combo].forEach(exec);
-    }
-  }
-
-  function filtered (handler) {
-    var filter = handler.filter;
-    if (!filter) {
-      return;
-    }
-
-    var el = e.target;
-    var selector = typeof filter === 'string';
-    if (selector) {
-      return sektor.matchesSelector(el, filter) === false;
-    }
-    while (el.parentElement && el !== filter) {
-      el = el.parentElement;
-    }
-    return el !== filter;
-  }
-
-  function exec (handler) {
-    if (filtered(handler)) {
-      return;
-    }
-    handler.handle(e);
-  }
-}
-
-module.exports = {
-  on: on,
-  off: off,
-  clear: clear,
-  handlers: handlers
-};
-
-},{"crossvent":16,"sektor":66}],66:[function(require,module,exports){
-(function (global){
-'use strict';
-
-var expando = 'sektor-' + Date.now();
-var rsiblings = /[+~]/;
-var document = global.document;
-var del = (document && document.documentElement) || {};
-var match = (
-  del.matches ||
-  del.webkitMatchesSelector ||
-  del.mozMatchesSelector ||
-  del.oMatchesSelector ||
-  del.msMatchesSelector ||
-  never
-);
-
-module.exports = sektor;
-
-sektor.matches = matches;
-sektor.matchesSelector = matchesSelector;
-
-function qsa (selector, context) {
-  var existed, id, prefix, prefixed, adapter, hack = context !== document;
-  if (hack) { // id hack for context-rooted queries
-    existed = context.getAttribute('id');
-    id = existed || expando;
-    prefix = '#' + id + ' ';
-    prefixed = prefix + selector.replace(/,/g, ',' + prefix);
-    adapter = rsiblings.test(selector) && context.parentNode;
-    if (!existed) { context.setAttribute('id', id); }
-  }
-  try {
-    return (adapter || context).querySelectorAll(prefixed || selector);
-  } catch (e) {
-    return [];
-  } finally {
-    if (existed === null) { context.removeAttribute('id'); }
-  }
-}
-
-function sektor (selector, ctx, collection, seed) {
-  var element;
-  var context = ctx || document;
-  var results = collection || [];
-  var i = 0;
-  if (typeof selector !== 'string') {
-    return results;
-  }
-  if (context.nodeType !== 1 && context.nodeType !== 9) {
-    return []; // bail if context is not an element or document
-  }
-  if (seed) {
-    while ((element = seed[i++])) {
-      if (matchesSelector(element, selector)) {
-        results.push(element);
-      }
-    }
-  } else {
-    results.push.apply(results, qsa(selector, context));
-  }
-  return results;
-}
-
-function matches (selector, elements) {
-  return sektor(selector, null, null, elements);
-}
-
-function matchesSelector (element, selector) {
-  return match.call(element, selector);
-}
-
-function never () { return false; }
-
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],67:[function(require,module,exports){
-(function (global){
-'use strict';
-
-var stub = require('./stub');
-var tracking = require('./tracking');
-var ls = 'localStorage' in global && global.localStorage ? global.localStorage : stub;
-
-function accessor (key, value) {
-  if (arguments.length === 1) {
-    return get(key);
-  }
-  return set(key, value);
-}
-
-function get (key) {
-  return JSON.parse(ls.getItem(key));
-}
-
-function set (key, value) {
-  try {
-    ls.setItem(key, JSON.stringify(value));
-    return true;
-  } catch (e) {
-    return false;
-  }
-}
-
-function remove (key) {
-  return ls.removeItem(key);
-}
-
-function clear () {
-  return ls.clear();
-}
-
-accessor.set = set;
-accessor.get = get;
-accessor.remove = remove;
-accessor.clear = clear;
-accessor.on = tracking.on;
-accessor.off = tracking.off;
-
-module.exports = accessor;
-
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./stub":68,"./tracking":69}],68:[function(require,module,exports){
-'use strict';
-
-var ms = {};
-
-function getItem (key) {
-  return key in ms ? ms[key] : null;
-}
-
-function setItem (key, value) {
-  ms[key] = value;
-  return true;
-}
-
-function removeItem (key) {
-  var found = key in ms;
-  if (found) {
-    return delete ms[key];
-  }
-  return false;
-}
-
-function clear () {
-  ms = {};
-  return true;
-}
-
-module.exports = {
-  getItem: getItem,
-  setItem: setItem,
-  removeItem: removeItem,
-  clear: clear
-};
-
-},{}],69:[function(require,module,exports){
-(function (global){
-'use strict';
-
-var listeners = {};
-var listening = false;
-
-function listen () {
-  if (global.addEventListener) {
-    global.addEventListener('storage', change, false);
-  } else if (global.attachEvent) {
-    global.attachEvent('onstorage', change);
-  } else {
-    global.onstorage = change;
-  }
-}
-
-function change (e) {
-  if (!e) {
-    e = global.event;
-  }
-  var all = listeners[e.key];
-  if (all) {
-    all.forEach(fire);
-  }
-
-  function fire (listener) {
-    listener(JSON.parse(e.newValue), JSON.parse(e.oldValue), e.url || e.uri);
-  }
-}
-
-function on (key, fn) {
-  if (listeners[key]) {
-    listeners[key].push(fn);
-  } else {
-    listeners[key] = [fn];
-  }
-  if (listening === false) {
-    listen();
-  }
-}
-
-function off (key, fn) {
-  var ns = listeners[key];
-  if (ns.length > 1) {
-    ns.splice(ns.indexOf(fn), 1);
-  } else {
-    listeners[key] = [];
-  }
-}
-
-module.exports = {
-  on: on,
-  off: off
-};
-
-}).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],70:[function(require,module,exports){
+},{"./isFunction":54,"./isObject":55,"./isSymbol":57}],60:[function(require,module,exports){
 'use strict';
 
 
 module.exports = require('./lib/');
 
-},{"./lib/":80}],71:[function(require,module,exports){
+},{"./lib/":70}],61:[function(require,module,exports){
 // HTML5 entities map: { name -> utf16string }
 //
 'use strict';
@@ -5872,7 +5564,7 @@ module.exports = require('./lib/');
 /*eslint quotes:0*/
 module.exports = require('entities/maps/entities.json');
 
-},{"entities/maps/entities.json":21}],72:[function(require,module,exports){
+},{"entities/maps/entities.json":20}],62:[function(require,module,exports){
 // List of valid html blocks names, accorting to commonmark spec
 // http://jgm.github.io/CommonMark/spec.html#html-blocks
 
@@ -5942,7 +5634,7 @@ module.exports = [
   'ul'
 ];
 
-},{}],73:[function(require,module,exports){
+},{}],63:[function(require,module,exports){
 // Regexps to match html elements
 
 'use strict';
@@ -5972,7 +5664,7 @@ var HTML_OPEN_CLOSE_TAG_RE = new RegExp('^(?:' + open_tag + '|' + close_tag + ')
 module.exports.HTML_TAG_RE = HTML_TAG_RE;
 module.exports.HTML_OPEN_CLOSE_TAG_RE = HTML_OPEN_CLOSE_TAG_RE;
 
-},{}],74:[function(require,module,exports){
+},{}],64:[function(require,module,exports){
 // List of valid url schemas, accorting to commonmark spec
 // http://jgm.github.io/CommonMark/spec.html#autolinks
 
@@ -6146,7 +5838,7 @@ module.exports = [
   'ymsgr'
 ];
 
-},{}],75:[function(require,module,exports){
+},{}],65:[function(require,module,exports){
 // Utilities
 //
 'use strict';
@@ -6423,7 +6115,7 @@ exports.isPunctChar         = isPunctChar;
 exports.escapeRE            = escapeRE;
 exports.normalizeReference  = normalizeReference;
 
-},{"./entities":71,"mdurl":128,"uc.micro":157,"uc.micro/categories/P/regex":155}],76:[function(require,module,exports){
+},{"./entities":61,"mdurl":124,"uc.micro":119,"uc.micro/categories/P/regex":117}],66:[function(require,module,exports){
 // Just a shortcut for bulk export
 'use strict';
 
@@ -6432,7 +6124,7 @@ exports.parseLinkLabel       = require('./parse_link_label');
 exports.parseLinkDestination = require('./parse_link_destination');
 exports.parseLinkTitle       = require('./parse_link_title');
 
-},{"./parse_link_destination":77,"./parse_link_label":78,"./parse_link_title":79}],77:[function(require,module,exports){
+},{"./parse_link_destination":67,"./parse_link_label":68,"./parse_link_title":69}],67:[function(require,module,exports){
 // Parse link destination
 //
 'use strict';
@@ -6513,7 +6205,7 @@ module.exports = function parseLinkDestination(str, pos, max) {
   return result;
 };
 
-},{"../common/utils":75}],78:[function(require,module,exports){
+},{"../common/utils":65}],68:[function(require,module,exports){
 // Parse link label
 //
 // this function assumes that first character ("[") already matches;
@@ -6563,7 +6255,7 @@ module.exports = function parseLinkLabel(state, start, disableNested) {
   return labelEnd;
 };
 
-},{}],79:[function(require,module,exports){
+},{}],69:[function(require,module,exports){
 // Parse link title
 //
 'use strict';
@@ -6618,7 +6310,7 @@ module.exports = function parseLinkTitle(str, pos, max) {
   return result;
 };
 
-},{"../common/utils":75}],80:[function(require,module,exports){
+},{"../common/utils":65}],70:[function(require,module,exports){
 // Main perser class
 
 'use strict';
@@ -7197,7 +6889,7 @@ MarkdownIt.prototype.renderInline = function (src, env) {
 
 module.exports = MarkdownIt;
 
-},{"./common/utils":75,"./helpers":76,"./parser_block":81,"./parser_core":82,"./parser_inline":83,"./presets/commonmark":84,"./presets/default":85,"./presets/zero":86,"./renderer":87,"linkify-it":123,"mdurl":128,"punycode":136}],81:[function(require,module,exports){
+},{"./common/utils":65,"./helpers":66,"./parser_block":71,"./parser_core":72,"./parser_inline":73,"./presets/commonmark":74,"./presets/default":75,"./presets/zero":76,"./renderer":77,"linkify-it":113,"mdurl":124,"punycode":131}],71:[function(require,module,exports){
 /** internal
  * class ParserBlock
  *
@@ -7324,7 +7016,7 @@ ParserBlock.prototype.State = require('./rules_block/state_block');
 
 module.exports = ParserBlock;
 
-},{"./ruler":88,"./rules_block/blockquote":89,"./rules_block/code":90,"./rules_block/fence":91,"./rules_block/heading":92,"./rules_block/hr":93,"./rules_block/html_block":94,"./rules_block/lheading":95,"./rules_block/list":96,"./rules_block/paragraph":97,"./rules_block/reference":98,"./rules_block/state_block":99,"./rules_block/table":100}],82:[function(require,module,exports){
+},{"./ruler":78,"./rules_block/blockquote":79,"./rules_block/code":80,"./rules_block/fence":81,"./rules_block/heading":82,"./rules_block/hr":83,"./rules_block/html_block":84,"./rules_block/lheading":85,"./rules_block/list":86,"./rules_block/paragraph":87,"./rules_block/reference":88,"./rules_block/state_block":89,"./rules_block/table":90}],72:[function(require,module,exports){
 /** internal
  * class Core
  *
@@ -7384,7 +7076,7 @@ Core.prototype.State = require('./rules_core/state_core');
 
 module.exports = Core;
 
-},{"./ruler":88,"./rules_core/block":101,"./rules_core/inline":102,"./rules_core/linkify":103,"./rules_core/normalize":104,"./rules_core/replacements":105,"./rules_core/smartquotes":106,"./rules_core/state_core":107}],83:[function(require,module,exports){
+},{"./ruler":78,"./rules_core/block":91,"./rules_core/inline":92,"./rules_core/linkify":93,"./rules_core/normalize":94,"./rules_core/replacements":95,"./rules_core/smartquotes":96,"./rules_core/state_core":97}],73:[function(require,module,exports){
 /** internal
  * class ParserInline
  *
@@ -7546,7 +7238,7 @@ ParserInline.prototype.State = require('./rules_inline/state_inline');
 
 module.exports = ParserInline;
 
-},{"./ruler":88,"./rules_inline/autolink":108,"./rules_inline/backticks":109,"./rules_inline/balance_pairs":110,"./rules_inline/emphasis":111,"./rules_inline/entity":112,"./rules_inline/escape":113,"./rules_inline/html_inline":114,"./rules_inline/image":115,"./rules_inline/link":116,"./rules_inline/newline":117,"./rules_inline/state_inline":118,"./rules_inline/strikethrough":119,"./rules_inline/text":120,"./rules_inline/text_collapse":121}],84:[function(require,module,exports){
+},{"./ruler":78,"./rules_inline/autolink":98,"./rules_inline/backticks":99,"./rules_inline/balance_pairs":100,"./rules_inline/emphasis":101,"./rules_inline/entity":102,"./rules_inline/escape":103,"./rules_inline/html_inline":104,"./rules_inline/image":105,"./rules_inline/link":106,"./rules_inline/newline":107,"./rules_inline/state_inline":108,"./rules_inline/strikethrough":109,"./rules_inline/text":110,"./rules_inline/text_collapse":111}],74:[function(require,module,exports){
 // Commonmark default options
 
 'use strict';
@@ -7628,7 +7320,7 @@ module.exports = {
   }
 };
 
-},{}],85:[function(require,module,exports){
+},{}],75:[function(require,module,exports){
 // markdown-it default options
 
 'use strict';
@@ -7671,7 +7363,7 @@ module.exports = {
   }
 };
 
-},{}],86:[function(require,module,exports){
+},{}],76:[function(require,module,exports){
 // "Zero" preset, with nothing enabled. Useful for manual configuring of simple
 // modes. For example, to parse bold/italic only.
 
@@ -7735,7 +7427,7 @@ module.exports = {
   }
 };
 
-},{}],87:[function(require,module,exports){
+},{}],77:[function(require,module,exports){
 /**
  * class Renderer
  *
@@ -8042,7 +7734,7 @@ Renderer.prototype.render = function (tokens, options, env) {
 
 module.exports = Renderer;
 
-},{"./common/utils":75}],88:[function(require,module,exports){
+},{"./common/utils":65}],78:[function(require,module,exports){
 /**
  * class Ruler
  *
@@ -8396,7 +8088,7 @@ Ruler.prototype.getRules = function (chainName) {
 
 module.exports = Ruler;
 
-},{}],89:[function(require,module,exports){
+},{}],79:[function(require,module,exports){
 // Block quotes
 
 'use strict';
@@ -8572,7 +8264,7 @@ module.exports = function blockquote(state, startLine, endLine, silent) {
   return true;
 };
 
-},{"../common/utils":75}],90:[function(require,module,exports){
+},{"../common/utils":65}],80:[function(require,module,exports){
 // Code block (4 spaces padded)
 
 'use strict';
@@ -8607,7 +8299,7 @@ module.exports = function code(state, startLine, endLine/*, silent*/) {
   return true;
 };
 
-},{}],91:[function(require,module,exports){
+},{}],81:[function(require,module,exports){
 // fences (``` lang, ~~~ lang)
 
 'use strict';
@@ -8700,7 +8392,7 @@ module.exports = function fence(state, startLine, endLine, silent) {
   return true;
 };
 
-},{}],92:[function(require,module,exports){
+},{}],82:[function(require,module,exports){
 // heading (#, ##, ...)
 
 'use strict';
@@ -8754,7 +8446,7 @@ module.exports = function heading(state, startLine, endLine, silent) {
   return true;
 };
 
-},{"../common/utils":75}],93:[function(require,module,exports){
+},{"../common/utils":65}],83:[function(require,module,exports){
 // Horizontal rule
 
 'use strict';
@@ -8798,7 +8490,7 @@ module.exports = function hr(state, startLine, endLine, silent) {
   return true;
 };
 
-},{"../common/utils":75}],94:[function(require,module,exports){
+},{"../common/utils":65}],84:[function(require,module,exports){
 // HTML block
 
 'use strict';
@@ -8871,7 +8563,7 @@ module.exports = function html_block(state, startLine, endLine, silent) {
   return true;
 };
 
-},{"../common/html_blocks":72,"../common/html_re":73}],95:[function(require,module,exports){
+},{"../common/html_blocks":62,"../common/html_re":63}],85:[function(require,module,exports){
 // lheading (---, ===)
 
 'use strict';
@@ -8923,7 +8615,7 @@ module.exports = function lheading(state, startLine, endLine/*, silent*/) {
   return true;
 };
 
-},{}],96:[function(require,module,exports){
+},{}],86:[function(require,module,exports){
 // Lists
 
 'use strict';
@@ -9224,7 +8916,7 @@ module.exports = function list(state, startLine, endLine, silent) {
   return true;
 };
 
-},{"../common/utils":75}],97:[function(require,module,exports){
+},{"../common/utils":65}],87:[function(require,module,exports){
 // Paragraph
 
 'use strict';
@@ -9273,7 +8965,7 @@ module.exports = function paragraph(state, startLine/*, endLine*/) {
   return true;
 };
 
-},{}],98:[function(require,module,exports){
+},{}],88:[function(require,module,exports){
 'use strict';
 
 
@@ -9466,7 +9158,7 @@ module.exports = function reference(state, startLine, _endLine, silent) {
   return true;
 };
 
-},{"../common/utils":75,"../helpers/parse_link_destination":77,"../helpers/parse_link_title":79}],99:[function(require,module,exports){
+},{"../common/utils":65,"../helpers/parse_link_destination":67,"../helpers/parse_link_title":69}],89:[function(require,module,exports){
 // Parser state class
 
 'use strict';
@@ -9675,7 +9367,7 @@ StateBlock.prototype.Token = Token;
 
 module.exports = StateBlock;
 
-},{"../common/utils":75,"../token":122}],100:[function(require,module,exports){
+},{"../common/utils":65,"../token":112}],90:[function(require,module,exports){
 // GFM table, non-standard
 
 'use strict';
@@ -9848,7 +9540,7 @@ module.exports = function table(state, startLine, endLine, silent) {
   return true;
 };
 
-},{}],101:[function(require,module,exports){
+},{}],91:[function(require,module,exports){
 'use strict';
 
 
@@ -9866,7 +9558,7 @@ module.exports = function block(state) {
   }
 };
 
-},{}],102:[function(require,module,exports){
+},{}],92:[function(require,module,exports){
 'use strict';
 
 module.exports = function inline(state) {
@@ -9881,7 +9573,7 @@ module.exports = function inline(state) {
   }
 };
 
-},{}],103:[function(require,module,exports){
+},{}],93:[function(require,module,exports){
 // Replace link-like texts with link nodes.
 //
 // Currently restricted by `md.validateLink()` to http/https/ftp
@@ -10016,7 +9708,7 @@ module.exports = function linkify(state) {
   }
 };
 
-},{"../common/utils":75}],104:[function(require,module,exports){
+},{"../common/utils":65}],94:[function(require,module,exports){
 // Normalize input string
 
 'use strict';
@@ -10038,7 +9730,7 @@ module.exports = function inline(state) {
   state.src = str;
 };
 
-},{}],105:[function(require,module,exports){
+},{}],95:[function(require,module,exports){
 // Simple typographyc replacements
 //
 // (c) (C) → ©
@@ -10129,7 +9821,7 @@ module.exports = function replace(state) {
   }
 };
 
-},{}],106:[function(require,module,exports){
+},{}],96:[function(require,module,exports){
 // Convert straight quotation marks to typographic ones
 //
 'use strict';
@@ -10324,7 +10016,7 @@ module.exports = function smartquotes(state) {
   }
 };
 
-},{"../common/utils":75}],107:[function(require,module,exports){
+},{"../common/utils":65}],97:[function(require,module,exports){
 // Core state object
 //
 'use strict';
@@ -10346,7 +10038,7 @@ StateCore.prototype.Token = Token;
 
 module.exports = StateCore;
 
-},{"../token":122}],108:[function(require,module,exports){
+},{"../token":112}],98:[function(require,module,exports){
 // Process autolinks '<protocol:...>'
 
 'use strict';
@@ -10424,7 +10116,7 @@ module.exports = function autolink(state, silent) {
   return false;
 };
 
-},{"../common/url_schemas":74}],109:[function(require,module,exports){
+},{"../common/url_schemas":64}],99:[function(require,module,exports){
 // Parse backticks
 
 'use strict';
@@ -10469,7 +10161,7 @@ module.exports = function backtick(state, silent) {
   return true;
 };
 
-},{}],110:[function(require,module,exports){
+},{}],100:[function(require,module,exports){
 // For each opening emphasis-like marker find a matching closing one
 //
 'use strict';
@@ -10507,7 +10199,7 @@ module.exports = function link_pairs(state) {
   }
 };
 
-},{}],111:[function(require,module,exports){
+},{}],101:[function(require,module,exports){
 // Process *this* and _that_
 //
 'use strict';
@@ -10632,7 +10324,7 @@ module.exports.postProcess = function emphasis(state) {
   }
 };
 
-},{}],112:[function(require,module,exports){
+},{}],102:[function(require,module,exports){
 // Process html entity - &#123;, &#xAF;, &quot;, ...
 
 'use strict';
@@ -10682,7 +10374,7 @@ module.exports = function entity(state, silent) {
   return true;
 };
 
-},{"../common/entities":71,"../common/utils":75}],113:[function(require,module,exports){
+},{"../common/entities":61,"../common/utils":65}],103:[function(require,module,exports){
 // Proceess escaped chars and hardbreaks
 
 'use strict';
@@ -10736,7 +10428,7 @@ module.exports = function escape(state, silent) {
   return true;
 };
 
-},{"../common/utils":75}],114:[function(require,module,exports){
+},{"../common/utils":65}],104:[function(require,module,exports){
 // Process html tags
 
 'use strict';
@@ -10785,7 +10477,7 @@ module.exports = function html_inline(state, silent) {
   return true;
 };
 
-},{"../common/html_re":73}],115:[function(require,module,exports){
+},{"../common/html_re":63}],105:[function(require,module,exports){
 // Process ![image](<src> "title")
 
 'use strict';
@@ -10949,7 +10641,7 @@ module.exports = function image(state, silent) {
   return true;
 };
 
-},{"../common/utils":75,"../helpers/parse_link_destination":77,"../helpers/parse_link_label":78,"../helpers/parse_link_title":79}],116:[function(require,module,exports){
+},{"../common/utils":65,"../helpers/parse_link_destination":67,"../helpers/parse_link_label":68,"../helpers/parse_link_title":69}],106:[function(require,module,exports){
 // Process [link](<to> "stuff")
 
 'use strict';
@@ -11105,7 +10797,7 @@ module.exports = function link(state, silent) {
   return true;
 };
 
-},{"../common/utils":75,"../helpers/parse_link_destination":77,"../helpers/parse_link_label":78,"../helpers/parse_link_title":79}],117:[function(require,module,exports){
+},{"../common/utils":65,"../helpers/parse_link_destination":67,"../helpers/parse_link_label":68,"../helpers/parse_link_title":69}],107:[function(require,module,exports){
 // Proceess '\n'
 
 'use strict';
@@ -11146,7 +10838,7 @@ module.exports = function newline(state, silent) {
   return true;
 };
 
-},{}],118:[function(require,module,exports){
+},{}],108:[function(require,module,exports){
 // Inline parser state
 
 'use strict';
@@ -11278,7 +10970,7 @@ StateInline.prototype.Token = Token;
 
 module.exports = StateInline;
 
-},{"../common/utils":75,"../token":122}],119:[function(require,module,exports){
+},{"../common/utils":65,"../token":112}],109:[function(require,module,exports){
 // ~~strike through~~
 //
 'use strict';
@@ -11397,7 +11089,7 @@ module.exports.postProcess = function strikethrough(state) {
   }
 };
 
-},{}],120:[function(require,module,exports){
+},{}],110:[function(require,module,exports){
 // Skip text characters for text token, place those to pending buffer
 // and increment current pos
 
@@ -11488,7 +11180,7 @@ module.exports = function text(state, silent) {
   return true;
 };*/
 
-},{}],121:[function(require,module,exports){
+},{}],111:[function(require,module,exports){
 // Merge adjacent text nodes into one, and re-calculate all token levels
 //
 'use strict';
@@ -11523,7 +11215,7 @@ module.exports = function text_collapse(state) {
   }
 };
 
-},{}],122:[function(require,module,exports){
+},{}],112:[function(require,module,exports){
 // Token class
 
 'use strict';
@@ -11708,7 +11400,7 @@ Token.prototype.attrJoin = function attrJoin(name, value) {
 
 module.exports = Token;
 
-},{}],123:[function(require,module,exports){
+},{}],113:[function(require,module,exports){
 'use strict';
 
 
@@ -12336,7 +12028,7 @@ LinkifyIt.prototype.normalize = function normalize(match) {
 
 module.exports = LinkifyIt;
 
-},{"./lib/re":124}],124:[function(require,module,exports){
+},{"./lib/re":114}],114:[function(require,module,exports){
 'use strict';
 
 // Use direct extract instead of `regenerate` to reduse browserified size
@@ -12500,7 +12192,26 @@ exports.tpl_link_no_ip_fuzzy =
     '(^|(?![.:/\\-_@])(?:[$+<=>^`|]|' + src_ZPCc + '))' +
     '((?![$+<=>^`|])' + tpl_host_port_no_ip_fuzzy_strict + src_path + ')';
 
-},{"uc.micro/categories/Cc/regex":153,"uc.micro/categories/P/regex":155,"uc.micro/categories/Z/regex":156,"uc.micro/properties/Any/regex":158}],125:[function(require,module,exports){
+},{"uc.micro/categories/Cc/regex":115,"uc.micro/categories/P/regex":117,"uc.micro/categories/Z/regex":118,"uc.micro/properties/Any/regex":120}],115:[function(require,module,exports){
+module.exports=/[\0-\x1F\x7F-\x9F]/
+},{}],116:[function(require,module,exports){
+module.exports=/[\xAD\u0600-\u0605\u061C\u06DD\u070F\u08E2\u180E\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u206F\uFEFF\uFFF9-\uFFFB]|\uD804\uDCBD|\uD82F[\uDCA0-\uDCA3]|\uD834[\uDD73-\uDD7A]|\uDB40[\uDC01\uDC20-\uDC7F]/
+},{}],117:[function(require,module,exports){
+module.exports=/[!-#%-\*,-/:;\?@\[-\]_\{\}\xA1\xA7\xAB\xB6\xB7\xBB\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u09FD\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166D\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E49\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]|\uD800[\uDD00-\uDD02\uDF9F\uDFD0]|\uD801\uDD6F|\uD802[\uDC57\uDD1F\uDD3F\uDE50-\uDE58\uDE7F\uDEF0-\uDEF6\uDF39-\uDF3F\uDF99-\uDF9C]|\uD804[\uDC47-\uDC4D\uDCBB\uDCBC\uDCBE-\uDCC1\uDD40-\uDD43\uDD74\uDD75\uDDC5-\uDDC9\uDDCD\uDDDB\uDDDD-\uDDDF\uDE38-\uDE3D\uDEA9]|\uD805[\uDC4B-\uDC4F\uDC5B\uDC5D\uDCC6\uDDC1-\uDDD7\uDE41-\uDE43\uDE60-\uDE6C\uDF3C-\uDF3E]|\uD806[\uDE3F-\uDE46\uDE9A-\uDE9C\uDE9E-\uDEA2]|\uD807[\uDC41-\uDC45\uDC70\uDC71]|\uD809[\uDC70-\uDC74]|\uD81A[\uDE6E\uDE6F\uDEF5\uDF37-\uDF3B\uDF44]|\uD82F\uDC9F|\uD836[\uDE87-\uDE8B]|\uD83A[\uDD5E\uDD5F]/
+},{}],118:[function(require,module,exports){
+module.exports=/[ \xA0\u1680\u2000-\u200A\u202F\u205F\u3000]/
+},{}],119:[function(require,module,exports){
+'use strict';
+
+exports.Any = require('./properties/Any/regex');
+exports.Cc  = require('./categories/Cc/regex');
+exports.Cf  = require('./categories/Cf/regex');
+exports.P   = require('./categories/P/regex');
+exports.Z   = require('./categories/Z/regex');
+
+},{"./categories/Cc/regex":115,"./categories/Cf/regex":116,"./categories/P/regex":117,"./categories/Z/regex":118,"./properties/Any/regex":120}],120:[function(require,module,exports){
+module.exports=/[\0-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/
+},{}],121:[function(require,module,exports){
 
 'use strict';
 
@@ -12624,7 +12335,7 @@ decode.componentChars = '';
 
 module.exports = decode;
 
-},{}],126:[function(require,module,exports){
+},{}],122:[function(require,module,exports){
 
 'use strict';
 
@@ -12724,7 +12435,7 @@ encode.componentChars = "-_.!~*'()";
 
 module.exports = encode;
 
-},{}],127:[function(require,module,exports){
+},{}],123:[function(require,module,exports){
 
 'use strict';
 
@@ -12751,7 +12462,7 @@ module.exports = function format(url) {
   return result;
 };
 
-},{}],128:[function(require,module,exports){
+},{}],124:[function(require,module,exports){
 'use strict';
 
 
@@ -12760,7 +12471,7 @@ module.exports.decode = require('./decode');
 module.exports.format = require('./format');
 module.exports.parse  = require('./parse');
 
-},{"./decode":125,"./encode":126,"./format":127,"./parse":129}],129:[function(require,module,exports){
+},{"./decode":121,"./encode":122,"./format":123,"./parse":125}],125:[function(require,module,exports){
 // Copyright Joyent, Inc. and other Node contributors.
 //
 // Permission is hereby granted, free of charge, to any person obtaining a
@@ -13074,7 +12785,7 @@ Url.prototype.parseHost = function(host) {
 
 module.exports = urlParse;
 
-},{}],130:[function(require,module,exports){
+},{}],126:[function(require,module,exports){
 'use strict';
 
 var MarkdownIt = require('markdown-it');
@@ -13402,7 +13113,7 @@ markdown.parser = md;
 markdown.languages = languages;
 module.exports = markdown;
 
-},{"./tokenizeLinks":132,"highlight.js":27,"markdown-it":70,"sluggish":148}],131:[function(require,module,exports){
+},{"./tokenizeLinks":128,"highlight.js":26,"markdown-it":60,"sluggish":143}],127:[function(require,module,exports){
 'use strict';
 
 var insane = require('insane');
@@ -13442,7 +13153,7 @@ markdown.languages.push('md-code', 'md-code-inline'); // only sanitizing purpose
 megamark.parser = markdown.parser;
 module.exports = megamark;
 
-},{"./markdown":130,"assignment":1,"highlight.js-tokens":36,"insane":56}],132:[function(require,module,exports){
+},{"./markdown":126,"assignment":1,"highlight.js-tokens":35,"insane":42}],128:[function(require,module,exports){
 'use strict';
 
 function arrayReplaceAt (a, i, middle) {
@@ -13607,7 +13318,7 @@ function tokenizeLinks (state, context) {
 
 module.exports = tokenizeLinks;
 
-},{}],133:[function(require,module,exports){
+},{}],129:[function(require,module,exports){
 //! moment.js
 
 ;(function (global, factory) {
@@ -18120,7 +17831,7 @@ module.exports = tokenizeLinks;
 
 })));
 
-},{}],134:[function(require,module,exports){
+},{}],130:[function(require,module,exports){
 var trim = require('trim')
   , forEach = require('for-each')
   , isArray = function(arg) {
@@ -18152,193 +17863,7 @@ module.exports = function (headers) {
 
   return result
 }
-},{"for-each":22,"trim":152}],135:[function(require,module,exports){
-// shim for using process in browser
-var process = module.exports = {};
-
-// cached from whatever global is present so that test runners that stub it
-// don't break things.  But we need to wrap it in a try catch in case it is
-// wrapped in strict mode code which doesn't define any globals.  It's inside a
-// function because try/catches deoptimize in certain engines.
-
-var cachedSetTimeout;
-var cachedClearTimeout;
-
-function defaultSetTimout() {
-    throw new Error('setTimeout has not been defined');
-}
-function defaultClearTimeout () {
-    throw new Error('clearTimeout has not been defined');
-}
-(function () {
-    try {
-        if (typeof setTimeout === 'function') {
-            cachedSetTimeout = setTimeout;
-        } else {
-            cachedSetTimeout = defaultSetTimout;
-        }
-    } catch (e) {
-        cachedSetTimeout = defaultSetTimout;
-    }
-    try {
-        if (typeof clearTimeout === 'function') {
-            cachedClearTimeout = clearTimeout;
-        } else {
-            cachedClearTimeout = defaultClearTimeout;
-        }
-    } catch (e) {
-        cachedClearTimeout = defaultClearTimeout;
-    }
-} ())
-function runTimeout(fun) {
-    if (cachedSetTimeout === setTimeout) {
-        //normal enviroments in sane situations
-        return setTimeout(fun, 0);
-    }
-    // if setTimeout wasn't available but was latter defined
-    if ((cachedSetTimeout === defaultSetTimout || !cachedSetTimeout) && setTimeout) {
-        cachedSetTimeout = setTimeout;
-        return setTimeout(fun, 0);
-    }
-    try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
-        return cachedSetTimeout(fun, 0);
-    } catch(e){
-        try {
-            // When we are in I.E. but the script has been evaled so I.E. doesn't trust the global object when called normally
-            return cachedSetTimeout.call(null, fun, 0);
-        } catch(e){
-            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error
-            return cachedSetTimeout.call(this, fun, 0);
-        }
-    }
-
-
-}
-function runClearTimeout(marker) {
-    if (cachedClearTimeout === clearTimeout) {
-        //normal enviroments in sane situations
-        return clearTimeout(marker);
-    }
-    // if clearTimeout wasn't available but was latter defined
-    if ((cachedClearTimeout === defaultClearTimeout || !cachedClearTimeout) && clearTimeout) {
-        cachedClearTimeout = clearTimeout;
-        return clearTimeout(marker);
-    }
-    try {
-        // when when somebody has screwed with setTimeout but no I.E. maddness
-        return cachedClearTimeout(marker);
-    } catch (e){
-        try {
-            // When we are in I.E. but the script has been evaled so I.E. doesn't  trust the global object when called normally
-            return cachedClearTimeout.call(null, marker);
-        } catch (e){
-            // same as above but when it's a version of I.E. that must have the global object for 'this', hopfully our context correct otherwise it will throw a global error.
-            // Some versions of I.E. have different rules for clearTimeout vs setTimeout
-            return cachedClearTimeout.call(this, marker);
-        }
-    }
-
-
-
-}
-var queue = [];
-var draining = false;
-var currentQueue;
-var queueIndex = -1;
-
-function cleanUpNextTick() {
-    if (!draining || !currentQueue) {
-        return;
-    }
-    draining = false;
-    if (currentQueue.length) {
-        queue = currentQueue.concat(queue);
-    } else {
-        queueIndex = -1;
-    }
-    if (queue.length) {
-        drainQueue();
-    }
-}
-
-function drainQueue() {
-    if (draining) {
-        return;
-    }
-    var timeout = runTimeout(cleanUpNextTick);
-    draining = true;
-
-    var len = queue.length;
-    while(len) {
-        currentQueue = queue;
-        queue = [];
-        while (++queueIndex < len) {
-            if (currentQueue) {
-                currentQueue[queueIndex].run();
-            }
-        }
-        queueIndex = -1;
-        len = queue.length;
-    }
-    currentQueue = null;
-    draining = false;
-    runClearTimeout(timeout);
-}
-
-process.nextTick = function (fun) {
-    var args = new Array(arguments.length - 1);
-    if (arguments.length > 1) {
-        for (var i = 1; i < arguments.length; i++) {
-            args[i - 1] = arguments[i];
-        }
-    }
-    queue.push(new Item(fun, args));
-    if (queue.length === 1 && !draining) {
-        runTimeout(drainQueue);
-    }
-};
-
-// v8 likes predictible objects
-function Item(fun, array) {
-    this.fun = fun;
-    this.array = array;
-}
-Item.prototype.run = function () {
-    this.fun.apply(null, this.array);
-};
-process.title = 'browser';
-process.browser = true;
-process.env = {};
-process.argv = [];
-process.version = ''; // empty string to avoid regexp issues
-process.versions = {};
-
-function noop() {}
-
-process.on = noop;
-process.addListener = noop;
-process.once = noop;
-process.off = noop;
-process.removeListener = noop;
-process.removeAllListeners = noop;
-process.emit = noop;
-process.prependListener = noop;
-process.prependOnceListener = noop;
-
-process.listeners = function (name) { return [] }
-
-process.binding = function (name) {
-    throw new Error('process.binding is not supported');
-};
-
-process.cwd = function () { return '/' };
-process.chdir = function (dir) {
-    throw new Error('process.chdir is not supported');
-};
-process.umask = function() { return 0; };
-
-},{}],136:[function(require,module,exports){
+},{"for-each":21,"trim":146}],131:[function(require,module,exports){
 (function (global){
 /*! https://mths.be/punycode v1.4.1 by @mathias */
 ;(function(root) {
@@ -18875,7 +18400,7 @@ process.umask = function() { return 0; };
 }(this));
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],137:[function(require,module,exports){
+},{}],132:[function(require,module,exports){
 /* Simple JavaScript Inheritance
  * By John Resig http://ejohn.org/
  * MIT Licensed.
@@ -18957,7 +18482,7 @@ process.umask = function() { return 0; };
   return Class;
 }));
 
-},{}],138:[function(require,module,exports){
+},{}],133:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -19032,7 +18557,7 @@ function matchesSelector (element, selector) {
 function never () { return false; }
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],139:[function(require,module,exports){
+},{}],134:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -19053,7 +18578,7 @@ if (isHost.method(global, 'getSelection')) {
 module.exports = getSelection;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./getSelectionNullOp":140,"./getSelectionRaw":141,"./getSelectionSynthetic":142,"./isHost":143}],140:[function(require,module,exports){
+},{"./getSelectionNullOp":135,"./getSelectionRaw":136,"./getSelectionSynthetic":137,"./isHost":138}],135:[function(require,module,exports){
 'use strict';
 
 function noop () {}
@@ -19067,7 +18592,7 @@ function getSelectionNullOp () {
 
 module.exports = getSelectionNullOp;
 
-},{}],141:[function(require,module,exports){
+},{}],136:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -19078,7 +18603,7 @@ function getSelectionRaw () {
 module.exports = getSelectionRaw;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],142:[function(require,module,exports){
+},{}],137:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -19332,7 +18857,7 @@ function getSelection () {
 module.exports = getSelection;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./rangeToTextRange":144}],143:[function(require,module,exports){
+},{"./rangeToTextRange":139}],138:[function(require,module,exports){
 'use strict';
 
 function isHostMethod (host, prop) {
@@ -19363,7 +18888,7 @@ module.exports = {
   properties: many(isHostProperty)
 };
 
-},{}],144:[function(require,module,exports){
+},{}],139:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -19427,7 +18952,7 @@ function createBoundaryTextRange (p, starting) {
 module.exports = rangeToTextRange;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],145:[function(require,module,exports){
+},{}],140:[function(require,module,exports){
 'use strict';
 
 var getSelection = require('./getSelection');
@@ -19438,7 +18963,7 @@ module.exports = {
   set: setSelection
 };
 
-},{"./getSelection":139,"./setSelection":146}],146:[function(require,module,exports){
+},{"./getSelection":134,"./setSelection":141}],141:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -19477,7 +19002,7 @@ function setSelection (p) {
 module.exports = setSelection;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./getSelection":139,"./rangeToTextRange":144}],147:[function(require,module,exports){
+},{"./getSelection":134,"./rangeToTextRange":139}],142:[function(require,module,exports){
 'use strict';
 
 var get = easyGet;
@@ -19575,7 +19100,7 @@ function sell (el, p) {
 
 module.exports = sell;
 
-},{}],148:[function(require,module,exports){
+},{}],143:[function(require,module,exports){
 'use strict';
 
 var spaces = /\s+/g;
@@ -19642,7 +19167,7 @@ function slug (text) {
 
 module.exports = slug;
 
-},{}],149:[function(require,module,exports){
+},{}],144:[function(require,module,exports){
 /*! http://mths.be/repeat v0.2.0 by @mathias */
 if (!String.prototype.repeat) {
 	(function() {
@@ -19694,8 +19219,7 @@ if (!String.prototype.repeat) {
 	}());
 }
 
-},{}],150:[function(require,module,exports){
-(function (setImmediate){
+},{}],145:[function(require,module,exports){
 var si = typeof setImmediate === 'function', tick;
 if (si) {
   tick = function (fn) { setImmediate(fn); };
@@ -19704,87 +19228,7 @@ if (si) {
 }
 
 module.exports = tick;
-}).call(this,require("timers").setImmediate)
-},{"timers":151}],151:[function(require,module,exports){
-(function (setImmediate,clearImmediate){
-var nextTick = require('process/browser.js').nextTick;
-var apply = Function.prototype.apply;
-var slice = Array.prototype.slice;
-var immediateIds = {};
-var nextImmediateId = 0;
-
-// DOM APIs, for completeness
-
-exports.setTimeout = function() {
-  return new Timeout(apply.call(setTimeout, window, arguments), clearTimeout);
-};
-exports.setInterval = function() {
-  return new Timeout(apply.call(setInterval, window, arguments), clearInterval);
-};
-exports.clearTimeout =
-exports.clearInterval = function(timeout) { timeout.close(); };
-
-function Timeout(id, clearFn) {
-  this._id = id;
-  this._clearFn = clearFn;
-}
-Timeout.prototype.unref = Timeout.prototype.ref = function() {};
-Timeout.prototype.close = function() {
-  this._clearFn.call(window, this._id);
-};
-
-// Does not start the time, just sets up the members needed.
-exports.enroll = function(item, msecs) {
-  clearTimeout(item._idleTimeoutId);
-  item._idleTimeout = msecs;
-};
-
-exports.unenroll = function(item) {
-  clearTimeout(item._idleTimeoutId);
-  item._idleTimeout = -1;
-};
-
-exports._unrefActive = exports.active = function(item) {
-  clearTimeout(item._idleTimeoutId);
-
-  var msecs = item._idleTimeout;
-  if (msecs >= 0) {
-    item._idleTimeoutId = setTimeout(function onTimeout() {
-      if (item._onTimeout)
-        item._onTimeout();
-    }, msecs);
-  }
-};
-
-// That's not how node.js implements it but the exposed api is the same.
-exports.setImmediate = typeof setImmediate === "function" ? setImmediate : function(fn) {
-  var id = nextImmediateId++;
-  var args = arguments.length < 2 ? false : slice.call(arguments, 1);
-
-  immediateIds[id] = true;
-
-  nextTick(function onNextTick() {
-    if (immediateIds[id]) {
-      // fn.call() is faster so we optimize for the common use-case
-      // @see http://jsperf.com/call-apply-segu
-      if (args) {
-        fn.apply(null, args);
-      } else {
-        fn.call(null);
-      }
-      // Prevent ids from leaking
-      exports.clearImmediate(id);
-    }
-  });
-
-  return id;
-};
-
-exports.clearImmediate = typeof clearImmediate === "function" ? clearImmediate : function(id) {
-  delete immediateIds[id];
-};
-}).call(this,require("timers").setImmediate,require("timers").clearImmediate)
-},{"process/browser.js":135,"timers":151}],152:[function(require,module,exports){
+},{}],146:[function(require,module,exports){
 
 exports = module.exports = trim;
 
@@ -19800,30 +19244,103 @@ exports.right = function(str){
   return str.replace(/\s*$/, '');
 };
 
-},{}],153:[function(require,module,exports){
-module.exports=/[\0-\x1F\x7F-\x9F]/
-},{}],154:[function(require,module,exports){
-module.exports=/[\xAD\u0600-\u0605\u061C\u06DD\u070F\u08E2\u180E\u200B-\u200F\u202A-\u202E\u2060-\u2064\u2066-\u206F\uFEFF\uFFF9-\uFFFB]|\uD804\uDCBD|\uD82F[\uDCA0-\uDCA3]|\uD834[\uDD73-\uDD7A]|\uDB40[\uDC01\uDC20-\uDC7F]/
-},{}],155:[function(require,module,exports){
-module.exports=/[!-#%-\*,-/:;\?@\[-\]_\{\}\xA1\xA7\xAB\xB6\xB7\xBB\xBF\u037E\u0387\u055A-\u055F\u0589\u058A\u05BE\u05C0\u05C3\u05C6\u05F3\u05F4\u0609\u060A\u060C\u060D\u061B\u061E\u061F\u066A-\u066D\u06D4\u0700-\u070D\u07F7-\u07F9\u0830-\u083E\u085E\u0964\u0965\u0970\u09FD\u0AF0\u0DF4\u0E4F\u0E5A\u0E5B\u0F04-\u0F12\u0F14\u0F3A-\u0F3D\u0F85\u0FD0-\u0FD4\u0FD9\u0FDA\u104A-\u104F\u10FB\u1360-\u1368\u1400\u166D\u166E\u169B\u169C\u16EB-\u16ED\u1735\u1736\u17D4-\u17D6\u17D8-\u17DA\u1800-\u180A\u1944\u1945\u1A1E\u1A1F\u1AA0-\u1AA6\u1AA8-\u1AAD\u1B5A-\u1B60\u1BFC-\u1BFF\u1C3B-\u1C3F\u1C7E\u1C7F\u1CC0-\u1CC7\u1CD3\u2010-\u2027\u2030-\u2043\u2045-\u2051\u2053-\u205E\u207D\u207E\u208D\u208E\u2308-\u230B\u2329\u232A\u2768-\u2775\u27C5\u27C6\u27E6-\u27EF\u2983-\u2998\u29D8-\u29DB\u29FC\u29FD\u2CF9-\u2CFC\u2CFE\u2CFF\u2D70\u2E00-\u2E2E\u2E30-\u2E49\u3001-\u3003\u3008-\u3011\u3014-\u301F\u3030\u303D\u30A0\u30FB\uA4FE\uA4FF\uA60D-\uA60F\uA673\uA67E\uA6F2-\uA6F7\uA874-\uA877\uA8CE\uA8CF\uA8F8-\uA8FA\uA8FC\uA92E\uA92F\uA95F\uA9C1-\uA9CD\uA9DE\uA9DF\uAA5C-\uAA5F\uAADE\uAADF\uAAF0\uAAF1\uABEB\uFD3E\uFD3F\uFE10-\uFE19\uFE30-\uFE52\uFE54-\uFE61\uFE63\uFE68\uFE6A\uFE6B\uFF01-\uFF03\uFF05-\uFF0A\uFF0C-\uFF0F\uFF1A\uFF1B\uFF1F\uFF20\uFF3B-\uFF3D\uFF3F\uFF5B\uFF5D\uFF5F-\uFF65]|\uD800[\uDD00-\uDD02\uDF9F\uDFD0]|\uD801\uDD6F|\uD802[\uDC57\uDD1F\uDD3F\uDE50-\uDE58\uDE7F\uDEF0-\uDEF6\uDF39-\uDF3F\uDF99-\uDF9C]|\uD804[\uDC47-\uDC4D\uDCBB\uDCBC\uDCBE-\uDCC1\uDD40-\uDD43\uDD74\uDD75\uDDC5-\uDDC9\uDDCD\uDDDB\uDDDD-\uDDDF\uDE38-\uDE3D\uDEA9]|\uD805[\uDC4B-\uDC4F\uDC5B\uDC5D\uDCC6\uDDC1-\uDDD7\uDE41-\uDE43\uDE60-\uDE6C\uDF3C-\uDF3E]|\uD806[\uDE3F-\uDE46\uDE9A-\uDE9C\uDE9E-\uDEA2]|\uD807[\uDC41-\uDC45\uDC70\uDC71]|\uD809[\uDC70-\uDC74]|\uD81A[\uDE6E\uDE6F\uDEF5\uDF37-\uDF3B\uDF44]|\uD82F\uDC9F|\uD836[\uDE87-\uDE8B]|\uD83A[\uDD5E\uDD5F]/
-},{}],156:[function(require,module,exports){
-module.exports=/[ \xA0\u1680\u2000-\u200A\u202F\u205F\u3000]/
-},{}],157:[function(require,module,exports){
+},{}],147:[function(require,module,exports){
 'use strict';
 
-exports.Any = require('./properties/Any/regex');
-exports.Cc  = require('./categories/Cc/regex');
-exports.Cf  = require('./categories/Cf/regex');
-exports.P   = require('./categories/P/regex');
-exports.Z   = require('./categories/Z/regex');
+var crossvent = require('crossvent');
+var throttle = require('./throttle');
+var tailormade = require('./tailormade');
 
-},{"./categories/Cc/regex":153,"./categories/Cf/regex":154,"./categories/P/regex":155,"./categories/Z/regex":156,"./properties/Any/regex":158}],158:[function(require,module,exports){
-module.exports=/[\0-\uD7FF\uE000-\uFFFF]|[\uD800-\uDBFF][\uDC00-\uDFFF]|[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/
-},{}],159:[function(require,module,exports){
+function bullseye (el, target, options) {
+  var o = options;
+  var domTarget = target && target.tagName;
+
+  if (!domTarget && arguments.length === 2) {
+    o = target;
+  }
+  if (!domTarget) {
+    target = el;
+  }
+  if (!o) { o = {}; }
+
+  var destroyed = false;
+  var throttledWrite = throttle(write, 30);
+  var tailorOptions = { update: o.autoupdateToCaret !== false && update };
+  var tailor = o.caret && tailormade(target, tailorOptions);
+
+  write();
+
+  if (o.tracking !== false) {
+    crossvent.add(window, 'resize', throttledWrite);
+  }
+
+  return {
+    read: readNull,
+    refresh: write,
+    destroy: destroy,
+    sleep: sleep
+  };
+
+  function sleep () {
+    tailorOptions.sleeping = true;
+  }
+
+  function readNull () { return read(); }
+
+  function read (readings) {
+    var bounds = target.getBoundingClientRect();
+    var scrollTop = document.body.scrollTop || document.documentElement.scrollTop;
+    if (tailor) {
+      readings = tailor.read();
+      return {
+        x: (readings.absolute ? 0 : bounds.left) + readings.x,
+        y: (readings.absolute ? 0 : bounds.top) + scrollTop + readings.y + 20
+      };
+    }
+    return {
+      x: bounds.left,
+      y: bounds.top + scrollTop
+    };
+  }
+
+  function update (readings) {
+    write(readings);
+  }
+
+  function write (readings) {
+    if (destroyed) {
+      throw new Error('Bullseye can\'t refresh after being destroyed. Create another instance instead.');
+    }
+    if (tailor && !readings) {
+      tailorOptions.sleeping = false;
+      tailor.refresh(); return;
+    }
+    var p = read(readings);
+    if (!tailor && target !== el) {
+      p.y += target.offsetHeight;
+    }
+    el.style.left = p.x + 'px';
+    el.style.top = p.y + 'px';
+  }
+
+  function destroy () {
+    if (tailor) { tailor.destroy(); }
+    crossvent.remove(window, 'resize', throttledWrite);
+    destroyed = true;
+  }
+}
+
+module.exports = bullseye;
+
+},{"./tailormade":148,"./throttle":149,"crossvent":150}],148:[function(require,module,exports){
+arguments[4][7][0].apply(exports,arguments)
+},{"./throttle":149,"crossvent":150,"dup":7,"seleccion":140,"sell":142}],149:[function(require,module,exports){
+arguments[4][8][0].apply(exports,arguments)
+},{"dup":8}],150:[function(require,module,exports){
 arguments[4][4][0].apply(exports,arguments)
-},{"./eventmap":160,"custom-event":18,"dup":4}],160:[function(require,module,exports){
+},{"./eventmap":151,"custom-event":17,"dup":4}],151:[function(require,module,exports){
 arguments[4][5][0].apply(exports,arguments)
-},{"dup":5}],161:[function(require,module,exports){
+},{"dup":5}],152:[function(require,module,exports){
 'use strict';
 
 var crossvent = require('crossvent');
@@ -20025,7 +19542,7 @@ function preventCtrlYZ (e) {
 
 module.exports = InputHistory;
 
-},{"./InputState":162,"crossvent":159}],162:[function(require,module,exports){
+},{"./InputState":153,"crossvent":150}],153:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -20108,7 +19625,7 @@ InputState.prototype.setChunks = function (chunk) {
 module.exports = InputState;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./fixEOL":169,"./html/HtmlChunks":173,"./isVisibleElement":182,"./markdown/MarkdownChunks":184}],163:[function(require,module,exports){
+},{"./fixEOL":160,"./html/HtmlChunks":164,"./isVisibleElement":173,"./markdown/MarkdownChunks":175}],154:[function(require,module,exports){
 'use strict';
 
 var crossvent = require('crossvent');
@@ -20211,7 +19728,7 @@ function bindCommands (surface, options, editor) {
 
 module.exports = bindCommands;
 
-},{"./html/blockquote":174,"./html/boldOrItalic":175,"./html/codeblock":176,"./html/heading":177,"./html/hr":178,"./html/linkOrImageOrAttachment":179,"./html/list":180,"./markdown/blockquote":185,"./markdown/boldOrItalic":186,"./markdown/codeblock":187,"./markdown/heading":188,"./markdown/hr":189,"./markdown/linkOrImageOrAttachment":190,"./markdown/list":191,"crossvent":159}],164:[function(require,module,exports){
+},{"./html/blockquote":165,"./html/boldOrItalic":166,"./html/codeblock":167,"./html/heading":168,"./html/hr":169,"./html/linkOrImageOrAttachment":170,"./html/list":171,"./markdown/blockquote":176,"./markdown/boldOrItalic":177,"./markdown/codeblock":178,"./markdown/heading":179,"./markdown/hr":180,"./markdown/linkOrImageOrAttachment":181,"./markdown/list":182,"crossvent":150}],155:[function(require,module,exports){
 'use strict';
 
 function cast (collection) {
@@ -20226,7 +19743,7 @@ function cast (collection) {
 
 module.exports = cast;
 
-},{}],165:[function(require,module,exports){
+},{}],156:[function(require,module,exports){
 'use strict';
 
 var rinput = /^\s*(.*?)(?:\s+"(.+)")?\s*$/;
@@ -20277,7 +19794,7 @@ function formatHref (url) {
 
 module.exports = parseLinkInput;
 
-},{}],166:[function(require,module,exports){
+},{}],157:[function(require,module,exports){
 'use strict';
 
 function trim (remove) {
@@ -20298,7 +19815,7 @@ function trim (remove) {
 
 module.exports = trim;
 
-},{}],167:[function(require,module,exports){
+},{}],158:[function(require,module,exports){
 'use strict';
 
 var rtrim = /^\s+|\s+$/g;
@@ -20320,7 +19837,7 @@ module.exports = {
   rm: rmClass
 };
 
-},{}],168:[function(require,module,exports){
+},{}],159:[function(require,module,exports){
 'use strict';
 
 function extendRegExp (regex, pre, post) {
@@ -20340,7 +19857,7 @@ function extendRegExp (regex, pre, post) {
 
 module.exports = extendRegExp;
 
-},{}],169:[function(require,module,exports){
+},{}],160:[function(require,module,exports){
 'use strict';
 
 function fixEOL (text) {
@@ -20349,7 +19866,7 @@ function fixEOL (text) {
 
 module.exports = fixEOL;
 
-},{}],170:[function(require,module,exports){
+},{}],161:[function(require,module,exports){
 'use strict';
 
 var InputState = require('./InputState');
@@ -20386,7 +19903,7 @@ function getCommandHandler (surface, history, fn) {
 
 module.exports = getCommandHandler;
 
-},{"./InputState":162}],171:[function(require,module,exports){
+},{"./InputState":153}],162:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -20606,7 +20123,7 @@ function surface (textarea, editable, droparea) {
 module.exports = surface;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./cast":164,"./fixEOL":169,"./many":183,"seleccion":145}],172:[function(require,module,exports){
+},{"./cast":155,"./fixEOL":160,"./many":174,"seleccion":140}],163:[function(require,module,exports){
 'use strict';
 
 function getText (el) {
@@ -20615,7 +20132,7 @@ function getText (el) {
 
 module.exports = getText;
 
-},{}],173:[function(require,module,exports){
+},{}],164:[function(require,module,exports){
 'use strict';
 
 var trimChunks = require('../chunks/trim');
@@ -20633,7 +20150,7 @@ HtmlChunks.prototype.skip = function () {
 
 module.exports = HtmlChunks;
 
-},{"../chunks/trim":166}],174:[function(require,module,exports){
+},{"../chunks/trim":157}],165:[function(require,module,exports){
 'use strict';
 
 var strings = require('../strings');
@@ -20645,7 +20162,7 @@ function blockquote (chunks) {
 
 module.exports = blockquote;
 
-},{"../strings":201,"./wrapping":181}],175:[function(require,module,exports){
+},{"../strings":192,"./wrapping":172}],166:[function(require,module,exports){
 'use strict';
 
 var strings = require('../strings');
@@ -20657,7 +20174,7 @@ function boldOrItalic (chunks, type) {
 
 module.exports = boldOrItalic;
 
-},{"../strings":201,"./wrapping":181}],176:[function(require,module,exports){
+},{"../strings":192,"./wrapping":172}],167:[function(require,module,exports){
 'use strict';
 
 var strings = require('../strings');
@@ -20669,7 +20186,7 @@ function codeblock (chunks) {
 
 module.exports = codeblock;
 
-},{"../strings":201,"./wrapping":181}],177:[function(require,module,exports){
+},{"../strings":192,"./wrapping":172}],168:[function(require,module,exports){
 'use strict';
 
 var strings = require('../strings');
@@ -20705,7 +20222,7 @@ function heading (chunks) {
 
 module.exports = heading;
 
-},{"../strings":201}],178:[function(require,module,exports){
+},{"../strings":192}],169:[function(require,module,exports){
 'use strict';
 
 function hr (chunks) {
@@ -20715,7 +20232,7 @@ function hr (chunks) {
 
 module.exports = hr;
 
-},{}],179:[function(require,module,exports){
+},{}],170:[function(require,module,exports){
 'use strict';
 
 var crossvent = require('crossvent');
@@ -20826,7 +20343,7 @@ function linkOrImageOrAttachment (chunks, options) {
 
 module.exports = linkOrImageOrAttachment;
 
-},{"../chunks/parseLinkInput":165,"../once":194,"../strings":201,"crossvent":159}],180:[function(require,module,exports){
+},{"../chunks/parseLinkInput":156,"../once":185,"../strings":192,"crossvent":150}],171:[function(require,module,exports){
 'use strict';
 
 var strings = require('../strings');
@@ -20899,7 +20416,7 @@ function list (chunks, ordered) {
 
 module.exports = list;
 
-},{"../strings":201}],181:[function(require,module,exports){
+},{"../strings":192}],172:[function(require,module,exports){
 'use strict';
 
 function wrapping (tag, placeholder, chunks) {
@@ -21010,7 +20527,7 @@ function surrounded (chunks, tag) {
 
 module.exports = wrapping;
 
-},{}],182:[function(require,module,exports){
+},{}],173:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -21025,7 +20542,7 @@ function isVisibleElement (elem) {
 module.exports = isVisibleElement;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],183:[function(require,module,exports){
+},{}],174:[function(require,module,exports){
 'use strict';
 
 function many (text, times) {
@@ -21034,7 +20551,7 @@ function many (text, times) {
 
 module.exports = many;
 
-},{}],184:[function(require,module,exports){
+},{}],175:[function(require,module,exports){
 'use strict';
 
 var many = require('../many');
@@ -21104,7 +20621,7 @@ MarkdownChunks.prototype.skip = function (options) {
 
 module.exports = MarkdownChunks;
 
-},{"../chunks/trim":166,"../extendRegExp":168,"../many":183}],185:[function(require,module,exports){
+},{"../chunks/trim":157,"../extendRegExp":159,"../many":174}],176:[function(require,module,exports){
 'use strict';
 
 var strings = require('../strings');
@@ -21232,7 +20749,7 @@ function blockquote (chunks) {
 
 module.exports = blockquote;
 
-},{"../strings":201,"./settings":192,"./wrapping":193}],186:[function(require,module,exports){
+},{"../strings":192,"./settings":183,"./wrapping":184}],177:[function(require,module,exports){
 'use strict';
 
 var rleading = /^(\**)/;
@@ -21271,7 +20788,7 @@ function boldOrItalic (chunks, type) {
 
 module.exports = boldOrItalic;
 
-},{"../strings":201}],187:[function(require,module,exports){
+},{"../strings":192}],178:[function(require,module,exports){
 'use strict';
 
 var strings = require('../strings');
@@ -21358,7 +20875,7 @@ function codeblock (chunks, options) {
 
 module.exports = codeblock;
 
-},{"../strings":201}],188:[function(require,module,exports){
+},{"../strings":192}],179:[function(require,module,exports){
 'use strict';
 
 var many = require('../many');
@@ -21407,7 +20924,7 @@ function heading (chunks) {
 
 module.exports = heading;
 
-},{"../many":183,"../strings":201}],189:[function(require,module,exports){
+},{"../many":174,"../strings":192}],180:[function(require,module,exports){
 'use strict';
 
 function hr (chunks) {
@@ -21418,7 +20935,7 @@ function hr (chunks) {
 
 module.exports = hr;
 
-},{}],190:[function(require,module,exports){
+},{}],181:[function(require,module,exports){
 'use strict';
 
 var once = require('../once');
@@ -21577,7 +21094,7 @@ function linkOrImageOrAttachment (chunks, options) {
 
 module.exports = linkOrImageOrAttachment;
 
-},{"../chunks/parseLinkInput":165,"../once":194,"../strings":201}],191:[function(require,module,exports){
+},{"../chunks/parseLinkInput":156,"../once":185,"../strings":192}],182:[function(require,module,exports){
 'use strict';
 
 var many = require('../many');
@@ -21666,14 +21183,14 @@ function list (chunks, ordered) {
 
 module.exports = list;
 
-},{"../many":183,"../strings":201,"./settings":192,"./wrapping":193}],192:[function(require,module,exports){
+},{"../many":174,"../strings":192,"./settings":183,"./wrapping":184}],183:[function(require,module,exports){
 'use strict';
 
 module.exports = {
   lineLength: 72
 };
 
-},{}],193:[function(require,module,exports){
+},{}],184:[function(require,module,exports){
 'use strict';
 
 var prefixes = '(?:\\s{4,}|\\s*>|\\s*-\\s+|\\s*\\d+\\.|=|\\+|-|_|\\*|#|\\s*\\[[^\n]]+\\]:)';
@@ -21704,7 +21221,7 @@ module.exports = {
   unwrap: unwrap
 };
 
-},{}],194:[function(require,module,exports){
+},{}],185:[function(require,module,exports){
 'use strict';
 
 function once (fn) {
@@ -21720,7 +21237,7 @@ function once (fn) {
 
 module.exports = once;
 
-},{}],195:[function(require,module,exports){
+},{}],186:[function(require,module,exports){
 'use strict';
 
 var doc = document;
@@ -21759,7 +21276,7 @@ function remove (prompts) {
 
 module.exports = closePrompts;
 
-},{}],196:[function(require,module,exports){
+},{}],187:[function(require,module,exports){
 'use strict';
 
 var crossvent = require('crossvent');
@@ -21932,7 +21449,7 @@ function prompt (options, done) {
 
 module.exports = prompt;
 
-},{"../classes":167,"../strings":201,"../uploads":202,"./render":197,"bureaucracy":9,"crossvent":159}],197:[function(require,module,exports){
+},{"../classes":158,"../strings":192,"../uploads":193,"./render":188,"bureaucracy":9,"crossvent":150}],188:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -22031,7 +21548,7 @@ render.uploads = uploads;
 module.exports = render;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"../classes":167,"../getText":172,"../setText":200,"../strings":201,"crossvent":159}],198:[function(require,module,exports){
+},{"../classes":158,"../getText":163,"../setText":191,"../strings":192,"crossvent":150}],189:[function(require,module,exports){
 'use strict';
 
 var bullseye = require('bullseye');
@@ -22078,7 +21595,7 @@ function rememberSelection (history) {
 
 module.exports = rememberSelection;
 
-},{"bullseye":6}],199:[function(require,module,exports){
+},{"bullseye":147}],190:[function(require,module,exports){
 'use strict';
 
 var setText = require('./setText');
@@ -22101,7 +21618,7 @@ module.exports = {
   commands: commands
 };
 
-},{"./setText":200,"./strings":201}],200:[function(require,module,exports){
+},{"./setText":191,"./strings":192}],191:[function(require,module,exports){
 'use strict';
 
 function setText (el, value) {
@@ -22110,7 +21627,7 @@ function setText (el, value) {
 
 module.exports = setText;
 
-},{}],201:[function(require,module,exports){
+},{}],192:[function(require,module,exports){
 'use strict';
 
 module.exports = {
@@ -22179,7 +21696,7 @@ module.exports = {
   }
 };
 
-},{}],202:[function(require,module,exports){
+},{}],193:[function(require,module,exports){
 'use strict';
 
 var crossvent = require('crossvent');
@@ -22249,7 +21766,7 @@ function dragstopper (droparea) {
 uploads.stop = dragstopper;
 module.exports = uploads;
 
-},{"./classes":167,"crossvent":159}],203:[function(require,module,exports){
+},{"./classes":158,"crossvent":150}],194:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -22615,7 +22132,7 @@ woofmark.strings = strings;
 module.exports = woofmark;
 
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"./InputHistory":161,"./bindCommands":163,"./classes":167,"./getCommandHandler":170,"./getSurface":171,"./prompts/close":195,"./prompts/prompt":196,"./rememberSelection":198,"./renderers":199,"./setText":200,"./strings":201,"./uploads":202,"crossvent":159,"kanye":65,"local-storage":67}],204:[function(require,module,exports){
+},{"./InputHistory":152,"./bindCommands":154,"./classes":158,"./getCommandHandler":161,"./getSurface":162,"./prompts/close":186,"./prompts/prompt":187,"./rememberSelection":189,"./renderers":190,"./setText":191,"./strings":192,"./uploads":193,"crossvent":150,"kanye":49,"local-storage":50}],195:[function(require,module,exports){
 module.exports = extend
 
 var hasOwnProperty = Object.prototype.hasOwnProperty;
@@ -22636,7 +22153,7 @@ function extend() {
     return target
 }
 
-},{}],205:[function(require,module,exports){
+},{}],196:[function(require,module,exports){
 var Class        = require('resig-class');
 
 PL = PublicLab = {};
@@ -22866,7 +22383,7 @@ PL.Editor = Class.extend({
 
 });
 
-},{"./PublicLab.Errors.js":206,"./PublicLab.Help.js":207,"./PublicLab.History.js":208,"./adapters/PublicLab.Formatter.js":209,"./adapters/PublicLab.Woofmark.js":210,"./core/Util.js":211,"./modules/PublicLab.MainImageModule.js":212,"./modules/PublicLab.MapModule.js":213,"./modules/PublicLab.Module.js":214,"./modules/PublicLab.RichTextModule.js":219,"./modules/PublicLab.TagsModule.js":220,"./modules/PublicLab.TitleModule.js":222,"resig-class":137}],206:[function(require,module,exports){
+},{"./PublicLab.Errors.js":197,"./PublicLab.Help.js":198,"./PublicLab.History.js":199,"./adapters/PublicLab.Formatter.js":200,"./adapters/PublicLab.Woofmark.js":201,"./core/Util.js":202,"./modules/PublicLab.MainImageModule.js":203,"./modules/PublicLab.MapModule.js":204,"./modules/PublicLab.Module.js":205,"./modules/PublicLab.RichTextModule.js":210,"./modules/PublicLab.TagsModule.js":211,"./modules/PublicLab.TitleModule.js":213,"resig-class":132}],197:[function(require,module,exports){
 /*
  * Error display; error format is:
  * "title": ["can't be blank"]
@@ -22900,7 +22417,7 @@ module.exports = PublicLab.Errors = Class.extend({
 
 });
 
-},{}],207:[function(require,module,exports){
+},{}],198:[function(require,module,exports){
 /*
  * UI behaviors and systems to provide helpful tips and guidance.
  */
@@ -22937,7 +22454,7 @@ module.exports = PublicLab.Help = Class.extend({
 
 });
 
-},{}],208:[function(require,module,exports){
+},{}],199:[function(require,module,exports){
 /*
  * History of edits, sorted by day. 
  */
@@ -23220,7 +22737,7 @@ module.exports = PublicLab.History = Class.extend({
 
 });
 
-},{"moment":133,"resig-class":137}],209:[function(require,module,exports){
+},{"moment":129,"resig-class":132}],200:[function(require,module,exports){
 /*
  * Formatters package the post content for a specific
  * application, like PublicLab.org or Drupal.
@@ -23285,7 +22802,7 @@ module.exports = PublicLab.Formatter = Class.extend({
 
 });
 
-},{"resig-class":137}],210:[function(require,module,exports){
+},{"resig-class":132}],201:[function(require,module,exports){
 /*
  * Wrapped woofmark() constructor with
  * customizations for our use case.
@@ -23645,7 +23162,7 @@ module.exports = function(textarea, _editor, _module) {
 
 }
 
-},{"../modules/PublicLab.RichTextModule.AutoCenter.js":215,"../modules/PublicLab.RichTextModule.Embed.js":216,"../modules/PublicLab.RichTextModule.HorizontalRule.js":217,"../modules/PublicLab.RichTextModule.Table.js":218,"banksy":3,"domador":19,"horsey":37,"megamark":131,"woofmark":203}],211:[function(require,module,exports){
+},{"../modules/PublicLab.RichTextModule.AutoCenter.js":206,"../modules/PublicLab.RichTextModule.Embed.js":207,"../modules/PublicLab.RichTextModule.HorizontalRule.js":208,"../modules/PublicLab.RichTextModule.Table.js":209,"banksy":3,"domador":18,"horsey":36,"megamark":127,"woofmark":194}],202:[function(require,module,exports){
 module.exports = {
 
   getUrlHashParameter: function(sParam) {
@@ -23685,7 +23202,7 @@ module.exports = {
 
 }
 
-},{}],212:[function(require,module,exports){
+},{}],203:[function(require,module,exports){
 /*
  * Form module for main post image
  */
@@ -23829,7 +23346,7 @@ module.exports = PublicLab.MainImageModule = PublicLab.Module.extend({
 
 });
 
-},{}],213:[function(require,module,exports){
+},{}],204:[function(require,module,exports){
 /*
       MapModule for adding Map .
       Adds/Removes Tag lat:XX , lon:XX from TagsModule .
@@ -23875,7 +23392,7 @@ module.exports = PublicLab.MapModule = PublicLab.Module.extend({
   }
 }) ;
 
-},{}],214:[function(require,module,exports){
+},{}],205:[function(require,module,exports){
 /*
  * Form modules like title, tags, body, main image
  */
@@ -23945,7 +23462,7 @@ module.exports = PublicLab.Module = Class.extend({
 
 });
 
-},{}],215:[function(require,module,exports){
+},{}],206:[function(require,module,exports){
 /*
    Auto Center insertion: ****
 */
@@ -23985,7 +23502,7 @@ module.exports = function initAutoCenter(_module, wysiwyg) {
   })
 }
 
-},{}],216:[function(require,module,exports){
+},{}],207:[function(require,module,exports){
 /* 
    Embed insertion: <iframe width="560" height="315" src="https://www.youtube.com/embed/Ej_l1hANqMc" frameborder="0" allowfullscreen></iframe>
 */   
@@ -24013,7 +23530,7 @@ module.exports = function initEmbed(_module, wysiwyg) {
 
 }
 
-},{}],217:[function(require,module,exports){
+},{}],208:[function(require,module,exports){
 /* 
    Horizontal Rule insertion: ****
 */   
@@ -24045,7 +23562,7 @@ module.exports = function initHorizontalRule(_module, wysiwyg) {
 
 }
 
-},{}],218:[function(require,module,exports){
+},{}],209:[function(require,module,exports){
 /*
  Table generation:
 
@@ -24153,7 +23670,7 @@ module.exports = function initTables(_module, wysiwyg) {
 
 }
 
-},{}],219:[function(require,module,exports){
+},{}],210:[function(require,module,exports){
 /*
  * Form module for rich text entry
  */
@@ -24365,9 +23882,13 @@ module.exports = PublicLab.RichTextModule = PublicLab.Module.extend({
       }
     });
 
-                crossvent.add(_module.wysiwyg.textarea, 'keyup', function (e) {
+    crossvent.add(_module.wysiwyg.textarea, 'keyup', function (e) {
       _editor.validate();
-      var regexp= /[\*]{2}[\s]{0,1}[\n]+[\#]{3}[^\P{P}*]+[\*]{2}/;
+      var regexp= /[\*]{2}[\s]{0,1}[\n]+[\#]+[^\P{P}*]+[\*]{2}/;
+      //checks for the following pattern
+      //<double asterisks><zero or one space>
+      //<atleast one new lines>
+      //<atleast one hash><include atleast one characters that is NOT an asterisk><double asterisks>
       if (_module.wysiwyg.mode == "markdown" && _module.value().match(regexp)) {
         _module.value(_module.value().match(regexp)[0].substr(3, _module.value().match(regexp)[0].length-5))
       }
@@ -24412,7 +23933,7 @@ module.exports = PublicLab.RichTextModule = PublicLab.Module.extend({
     } else {
     wk_c.style.bottom = document.getElementsByClassName('ple-footer')[0].getBoundingClientRect().height + "px";
     wk_c.style.position = "fixed";
-    wk_c.style.zIndex = 999;
+    wk_c.style.zIndex = 2;
    }
   })
 
@@ -24420,7 +23941,7 @@ module.exports = PublicLab.RichTextModule = PublicLab.Module.extend({
 
 });
 
-},{"crossvent":16}],220:[function(require,module,exports){
+},{"crossvent":15}],211:[function(require,module,exports){
 /*
  * Form module for post tags
  */
@@ -24542,7 +24063,7 @@ module.exports = PublicLab.TagsModule = PublicLab.Module.extend({
 
 });
 
-},{}],221:[function(require,module,exports){
+},{}],212:[function(require,module,exports){
 /* Displays related posts to associate this one with. 
  * Pass this a fetchRelated() method which runs show() with returned JSON data.
  * Example:
@@ -24645,7 +24166,7 @@ module.exports = function relatedNodes(module) {
 
 }
 
-},{}],222:[function(require,module,exports){
+},{}],213:[function(require,module,exports){
 /*
  * Form module for post title
  */
@@ -24777,4 +24298,4 @@ module.exports = PublicLab.TitleModule = PublicLab.Module.extend({
 });
 
 
-},{"./PublicLab.TitleModule.Related.js":221}]},{},[205]);
+},{"./PublicLab.TitleModule.Related.js":212}]},{},[196]);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "publiclab-editor",
-  "version": "1.3.4",
+  "version": "1.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -803,6 +803,36 @@
         "crossvent": "^1.3.1",
         "seleccion": "2.0.0",
         "sell": "^1.0.0"
+      }
+    },
+    "bureaucracy": {
+      "version": "git://github.com/jywarren/bureaucracy.git#f2522f42eba0f09444971e7138a56179cd8bffa9",
+      "from": "git://github.com/jywarren/bureaucracy.git#xhrOptions",
+      "requires": {
+        "contra": "1.9.4",
+        "crossvent": "1.5.4",
+        "xhr": "2.2.1"
+      },
+      "dependencies": {
+        "crossvent": {
+          "version": "1.5.4",
+          "resolved": "https://registry.npmjs.org/crossvent/-/crossvent-1.5.4.tgz",
+          "integrity": "sha1-2ixPj0DJR4JRe/K+7BBEFIGUq5I=",
+          "requires": {
+            "custom-event": "1.0.0"
+          }
+        },
+        "xhr": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.2.1.tgz",
+          "integrity": "sha1-MjxNG/dp+J3xtRs2gHzT66lIA2I=",
+          "requires": {
+            "global": "~4.3.0",
+            "is-function": "^1.0.1",
+            "parse-headers": "^2.0.0",
+            "xtend": "^4.0.0"
+          }
+        }
       }
     },
     "bytes": {
@@ -3266,6 +3296,11 @@
         "pinkie-promise": "^2.0.0"
       }
     },
+    "haversine-distance": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/haversine-distance/-/haversine-distance-1.1.4.tgz",
+      "integrity": "sha512-ElW49a3HbKhoIlFQ7gGvazYyi9etz5e1hrUDS/Z9MCvtm5iQm1YAvd9Rx8Oy121h+0X7PbsjBBRKDH4Otr0JuA=="
+    },
     "hawk": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
@@ -3966,6 +4001,21 @@
         "inherits": "^2.0.1",
         "isarray": "~0.0.1",
         "stream-splicer": "^2.0.0"
+      }
+    },
+    "leaflet": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.4.0.tgz",
+      "integrity": "sha512-x9j9tGY1+PDLN9pcWTx9/y6C5nezoTMB8BLK5jTakx+H7bPlnbCHfi9Hjg+Qt36sgDz/cb9lrSpNQXmk45Tvhw=="
+    },
+    "leaflet-blurred-location": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/leaflet-blurred-location/-/leaflet-blurred-location-1.2.5.tgz",
+      "integrity": "sha512-4YNuHWgg7JJh0MM/+qYSzU+RSyNKHH2bB6YaxxDExYEqr6J4K7fkn4yG6Mvs5p1AofzqwWCbucNLL3yVDUcZiQ==",
+      "requires": {
+        "haversine-distance": "^1.1.4",
+        "jquery": "^3.2.1",
+        "leaflet": "^1.3.3"
       }
     },
     "levn": {
@@ -6851,7 +6901,7 @@
     },
     "woofmark": {
       "version": "git://github.com/jywarren/woofmark.git#12e2c1d4559268e2de605ad6084d5dce24ea42c6",
-      "from": "git://github.com/jywarren/woofmark.git#12e2c1d4559268e2de605ad6084d5dce24ea42c6",
+      "from": "git://github.com/jywarren/woofmark.git#xhrOptionsAltBureaucracy",
       "requires": {
         "bullseye": "1.4.6",
         "bureaucracy": "git://github.com/jywarren/bureaucracy.git#f2522f42eba0f09444971e7138a56179cd8bffa9",
@@ -6871,42 +6921,12 @@
             "sell": "^1.0.0"
           }
         },
-        "bureaucracy": {
-          "version": "git://github.com/jywarren/bureaucracy.git#f2522f42eba0f09444971e7138a56179cd8bffa9",
-          "from": "git://github.com/jywarren/bureaucracy.git#f2522f42eba0f09444971e7138a56179cd8bffa9",
-          "requires": {
-            "contra": "1.9.4",
-            "crossvent": "1.5.4",
-            "xhr": "2.2.1"
-          },
-          "dependencies": {
-            "crossvent": {
-              "version": "1.5.4",
-              "resolved": "https://registry.npmjs.org/crossvent/-/crossvent-1.5.4.tgz",
-              "integrity": "sha1-2ixPj0DJR4JRe/K+7BBEFIGUq5I=",
-              "requires": {
-                "custom-event": "1.0.0"
-              }
-            }
-          }
-        },
         "crossvent": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/crossvent/-/crossvent-1.5.0.tgz",
           "integrity": "sha1-N3nBJCaZ4ZQX8EFOYbFEdTpS/W0=",
           "requires": {
             "custom-event": "1.0.0"
-          }
-        },
-        "xhr": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/xhr/-/xhr-2.2.1.tgz",
-          "integrity": "sha1-MjxNG/dp+J3xtRs2gHzT66lIA2I=",
-          "requires": {
-            "global": "~4.3.0",
-            "is-function": "^1.0.1",
-            "parse-headers": "^2.0.0",
-            "xtend": "^4.0.0"
           }
         }
       }

--- a/src/modules/PublicLab.RichTextModule.js
+++ b/src/modules/PublicLab.RichTextModule.js
@@ -260,7 +260,7 @@ module.exports = PublicLab.RichTextModule = PublicLab.Module.extend({
     } else {
     wk_c.style.bottom = document.getElementsByClassName('ple-footer')[0].getBoundingClientRect().height + "px";
     wk_c.style.position = "fixed";
-    wk_c.style.zIndex = 999;
+    wk_c.style.zIndex = 2;
    }
   })
 


### PR DESCRIPTION
Fixes #246. z-index of the button group has been reduced to 2 and z-index of any prompts that may appear when you click those buttons has been increased to 999. This way the buttons may never overlap the prompt. Here is a [screenshot](https://user-images.githubusercontent.com/4411767/51543911-f8b6cf00-1e5e-11e9-8558-5371b561ff83.png).