### PR TITLE
Fix RichTextModule command buttons on firefox.

### DIFF
--- a/dist/PublicLab.Editor.js
+++ b/dist/PublicLab.Editor.js
@@ -21807,7 +21807,7 @@ module.exports = function initAutoCenter(_module, wysiwyg) {
   // $('.woofmark-mode-markdown').removeClass('disabled')
 
   // create a menu option for auto center:
-  $('.wk-commands').append('<button class="btn-autocenter"><a class="woofmark-command-autocenter btn btn-default" data-toggle="autocenter" title="<center> In Rich mode, insert spaces for images."><i class="fa fa-align-center"></i></a></button>');
+  $('.wk-commands').append('<a class="btn-autocenter"><a class="woofmark-command-autocenter btn btn-default" data-toggle="autocenter" title="<center> In Rich mode, insert spaces for images."><i class="fa fa-align-center"></i></a></a>');
   //since chunk.selection returns null for images
 
   $('.btn-autocenter').css({
@@ -21845,7 +21845,7 @@ module.exports = function initAutoCenter(_module, wysiwyg) {
 module.exports = function initEmbed(_module, wysiwyg) {
 
   // create a menu option for embeds:
-  $('.wk-commands').append('<button class="btn-youtube"><a class="woofmark-command-embed btn btn-default" data-toggle="youtube" title="Youtube link <iframe>"><i class="fa fa-youtube"></i></a></button>');
+  $('.wk-commands').append('<a class="btn-youtube"><a class="woofmark-command-embed btn btn-default" data-toggle="youtube" title="Youtube link <iframe>"><i class="fa fa-youtube"></i></a></a>');
 
   $('.btn-youtube').css({
     padding: 0,
@@ -21873,7 +21873,7 @@ module.exports = function initEmbed(_module, wysiwyg) {
 module.exports = function initHorizontalRule(_module, wysiwyg) {
 
   // create a menu option for horizontal rules:
-  $('.wk-commands').append('<button class="btn-horizontal"><a class="woofmark-command-horizontal-rule btn btn-default" data-toggle="horizontal" title="Horizontal line <hr>"><i class="fa fa-ellipsis-h"></i></a></button>');
+  $('.wk-commands').append('<a class="btn-horizontal"><a class="woofmark-command-horizontal-rule btn btn-default" data-toggle="horizontal" title="Horizontal line <hr>"><i class="fa fa-ellipsis-h"></i></a></a>');
 
   $('.btn-horizontal').css({
     padding: 0,
@@ -21952,7 +21952,7 @@ module.exports = function initTables(_module, wysiwyg) {
 
 
   // create a submenu for sizing tables
-  $('.wk-commands').append('<button class="btn-table"><a class="woofmark-command-table btn btn-default" data-toggle="table" title="Table <table>"><i class="fa fa-table"></i></a></button>');
+  $('.wk-commands').append('<a class="btn-table"><a class="woofmark-command-table btn btn-default" data-toggle="table" title="Table <table>"><i class="fa fa-table"></i></a></a>');
 
   $('.btn-table').css({
     padding: 0,

--- a/examples/index.html
+++ b/examples/index.html
@@ -93,6 +93,13 @@
           </div>
         </div>
         <!-- end selector module -->
+        <p>
+          Open Source
+          <a href="https://github.com/publiclab/PublicLab.Editor">
+            <i class="fa fa-github"></i>
+          </a>
+         by <a href= "https://publiclab.org" title = "Public Lab website"><i class = "fa fa-globe"></i> Public Lab</a>
+        </p>
       </div>
 
       <div class="ple-content">

--- a/src/modules/PublicLab.RichTextModule.AutoCenter.js
+++ b/src/modules/PublicLab.RichTextModule.AutoCenter.js
@@ -7,7 +7,7 @@ module.exports = function initAutoCenter(_module, wysiwyg) {
   // $('.woofmark-mode-markdown').removeClass('disabled')
 
   // create a menu option for auto center:
-  $('.wk-commands').append('<button class="btn-autocenter"><a class="woofmark-command-autocenter btn btn-default" data-toggle="autocenter" title="<center> In Rich mode, insert spaces for images."><i class="fa fa-align-center"></i></a></button>');
+  $('.wk-commands').append('<a class="btn-autocenter"><a class="woofmark-command-autocenter btn btn-default" data-toggle="autocenter" title="<center> In Rich mode, insert spaces for images."><i class="fa fa-align-center"></i></a></a>');
   //since chunk.selection returns null for images
 
   $('.btn-autocenter').css({

--- a/src/modules/PublicLab.RichTextModule.Embed.js
+++ b/src/modules/PublicLab.RichTextModule.Embed.js
@@ -5,7 +5,7 @@
 module.exports = function initEmbed(_module, wysiwyg) {
 
   // create a menu option for embeds:
-  $('.wk-commands').append('<button class="btn-youtube"><a class="woofmark-command-embed btn btn-default" data-toggle="youtube" title="Youtube link <iframe>"><i class="fa fa-youtube"></i></a></button>');
+  $('.wk-commands').append('<a class="btn-youtube"><a class="woofmark-command-embed btn btn-default" data-toggle="youtube" title="Youtube link <iframe>"><i class="fa fa-youtube"></i></a></a>');
 
   $('.btn-youtube').css({
     padding: 0,

--- a/src/modules/PublicLab.RichTextModule.HorizontalRule.js
+++ b/src/modules/PublicLab.RichTextModule.HorizontalRule.js
@@ -5,7 +5,7 @@
 module.exports = function initHorizontalRule(_module, wysiwyg) {
 
   // create a menu option for horizontal rules:
-  $('.wk-commands').append('<button class="btn-horizontal"><a class="woofmark-command-horizontal-rule btn btn-default" data-toggle="horizontal" title="Horizontal line <hr>"><i class="fa fa-ellipsis-h"></i></a></button>');
+  $('.wk-commands').append('<a class="btn-horizontal"><a class="woofmark-command-horizontal-rule btn btn-default" data-toggle="horizontal" title="Horizontal line <hr>"><i class="fa fa-ellipsis-h"></i></a></a>');
 
   $('.btn-horizontal').css({
     padding: 0,

--- a/src/modules/PublicLab.RichTextModule.Table.js
+++ b/src/modules/PublicLab.RichTextModule.Table.js
@@ -52,7 +52,7 @@ module.exports = function initTables(_module, wysiwyg) {
 
 
   // create a submenu for sizing tables
-  $('.wk-commands').append('<button class="btn-table"><a class="woofmark-command-table btn btn-default" data-toggle="table" title="Table <table>"><i class="fa fa-table"></i></a></button>');
+  $('.wk-commands').append('<a class="btn-table"><a class="woofmark-command-table btn btn-default" data-toggle="table" title="Table <table>"><i class="fa fa-table"></i></a></a>');
 
   $('.btn-table').css({
     padding: 0,


### PR DESCRIPTION
Someone created an Issue in [plots2 ](https://github.com/publiclab/plots2 )repo here. "[Multiple Issues With Text Editor in Firefox 65 vs/and Chrome 72.0](https://github.com/publiclab/plots2/issues/4908)"
This PR fixes Issue 1. 

It was caused due to Phrasing content restrictions as <button> tag cannot have a descendant interactive <a> tag. It works on chrome because they don't restrict it, but Mozilla does according to W3C HTML guidelines.

Since we are using Bootstrap in plots2, we can get around by using <a> instead of button with class="btn".


Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt jasmine`
* [x] code is in uniquely-named feature branch and has no merge conflicts
* [x] PR is descriptively titled
* [x] PR body includes `fixes #0000`-style reference to original issue #
* [x] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!