### PR TITLE
ADD: Filter queries

### DIFF
--- a/examples/data/atwho.PLE.js
+++ b/examples/data/atwho.PLE.js
@@ -46,6 +46,11 @@ var hashtag_watcher = {
       return value;
     },
     remoteFilter: function(query, callback) {
+      if (Number.isInteger(Number(query))) {
+        callback(null);
+        return;
+      }
+
       $.getJSON(
         "https://publiclab.org/api/srch/tags?query=" + query,
         {},


### PR DESCRIPTION
@jywarren as you've requested, we won't make an API call. On the other hand, if it is a string(or string that contains a number like `#bm2`) it will make a request. 

`callback(null)` on line 50 is required because when user types something and deletes it leaving the empty hashtag(`#`) the suggestions modal still persist. This callback call closes modal on empty `#`.

@SidharthBansal could you also review this, please?
Thanks.

Resolves: #55

