### PR TITLE
FIX: RichTextModule constantly updating elements

### DIFF
--- a/dist/PublicLab.Editor.js
+++ b/dist/PublicLab.Editor.js
@@ -21960,11 +21960,19 @@ module.exports = function initTables(_module, wysiwyg) {
   });
 
   var builder  = '<div class="form-inline form-group ple-table-popover" style="width:400px;">';
-      builder += '<input value="4" class="form-control rows" style="width:75px;" />';
-      builder += ' x ';
-      builder += '<input value="3" class="form-control cols" style="width:85px;" /> ';
-      builder += '<a class="ple-table-size btn btn-default"><i class="fa fa-plus"></i></a>';
-      builder += '</div>';
+        builder += '<a id="decRows" class="btn btn-sm btn-default"><i class="fa fa-minus"></i></a> <span id="tableRows">4</span> <a id="incRows" class="btn btn-sm btn-default"><i class="fa fa-plus"></i></a>';
+        builder += ' x ';
+        builder += '<a id="decCols" class="btn btn-sm btn-default"><i class="fa fa-minus"></i></a> <span id="tableCols">3</span> <a id="incCols" class="btn btn-sm btn-default"><i class="fa fa-plus"></i></a>';
+        builder += '&nbsp;<a class="ple-table-size btn btn-default">Add</a>';
+        builder += '</div>';
+
+    $('.woofmark-command-table').attr('data-content', builder);
+
+
+    $(document).on('click', '#incRows', function(){ $("#tableRows").text( Number($("#tableRows").text()) + 1 ); });
+    $(document).on('click', '#decRows', function(){ $("#tableRows").text( Number($("#tableRows").text()) - 1 ); });
+    $(document).on('click', '#incCols', function(){ $("#tableCols").text( Number($("#tableCols").text()) + 1 ); });
+    $(document).on('click', '#decCols', function(){ $("#tableCols").text( Number($("#tableCols").text()) - 1 ); });
 
   $('.woofmark-command-table').attr('data-content', builder);
   $('.woofmark-command-table').attr('data-container', 'body');
@@ -21979,8 +21987,8 @@ module.exports = function initTables(_module, wysiwyg) {
       wysiwyg.runCommand(function(chunks, mode) {
 
         var table = createTable(
-          +$('.ple-table-popover .cols').val(),
-          +$('.ple-table-popover .rows').val()
+          +Number($('.ple-table-popover #tableCols').text()),
+          +Number($('.ple-table-popover #tableRows').text())
         );
 
         if (mode === 'markdown') chunks.before += table;
@@ -22183,7 +22191,6 @@ module.exports = PublicLab.RichTextModule = PublicLab.Module.extend({
       }
     };
 
-    setInterval(autocenterCheck, 100);
 
     crossvent.add(_module.wysiwyg.editable, "keydown", autocenterCheck);
 

--- a/src/modules/PublicLab.RichTextModule.js
+++ b/src/modules/PublicLab.RichTextModule.js
@@ -179,8 +179,6 @@ module.exports = PublicLab.RichTextModule = PublicLab.Module.extend({
       }
     };
 
-    setInterval(autocenterCheck, 100);
-
     crossvent.add(_module.wysiwyg.editable, "keydown", autocenterCheck);
 
     crossvent.add(_module.wysiwyg.editable, "keyup", function(e) {


### PR DESCRIPTION
In the old version, RichTextModule would run autocenterCheck every 100ms.
It's a performance issue and it's also redundant because we run this function on keydown event.

Resolves https://github.com/publiclab/plots2/issues/6989
