### PR TITLE
FIX: Error modal when dragging uploaded images

### DIFF
--- a/dist/PublicLab.Editor.js
+++ b/dist/PublicLab.Editor.js
@@ -20480,6 +20480,7 @@ PL.MapModule       = require('./modules/PublicLab.MapModule.js');
 $(document).ready(function() {
   PL.Util.preventModalScrollToTop();
   PL.Util.enableRichTextModeKeyboardShortcut();
+  PL.Util.preventUploadedImagesDragging();
 });
 
 PL.Editor = Class.extend({
@@ -21607,6 +21608,32 @@ module.exports = {
         toggleMarkdownModeBtn.style.display = 'block';
       }
     });
+  },
+
+  preventUploadedImagesDragging: function() {
+    var wysiwygDiv = document.querySelector(".wk-wysiwyg");
+    var self = this;
+
+    if(!wysiwygDiv) return;
+
+    function handleChange() {
+      if (window.isScrollingDisabled) {
+        self.enableScroll();
+      }
+
+      var imageElements = document.querySelectorAll(
+        '.wk-wysiwyg img:not([draggable="false"])'
+      );
+
+      imageElements.forEach(function(imageElement) {
+        imageElement.setAttribute("draggable", "false");
+      });
+    }
+
+    var observerConfig = { childList: true, subtree: true };
+    var wysiwygDivObserver = new MutationObserver(handleChange);
+
+    wysiwygDivObserver.observe(wysiwygDiv, observerConfig);
   }
 
 }

--- a/src/PublicLab.Editor.js
+++ b/src/PublicLab.Editor.js
@@ -19,6 +19,7 @@ PL.MapModule       = require('./modules/PublicLab.MapModule.js');
 $(document).ready(function() {
   PL.Util.preventModalScrollToTop();
   PL.Util.enableRichTextModeKeyboardShortcut();
+  PL.Util.preventUploadedImagesDragging();
 });
 
 PL.Editor = Class.extend({

--- a/src/core/Util.js
+++ b/src/core/Util.js
@@ -104,6 +104,32 @@ module.exports = {
         toggleMarkdownModeBtn.style.display = 'block';
       }
     });
+  },
+
+  preventUploadedImagesDragging: function() {
+    var wysiwygDiv = document.querySelector(".wk-wysiwyg");
+    var self = this;
+
+    if(!wysiwygDiv) return;
+
+    function handleChange() {
+      if (window.isScrollingDisabled) {
+        self.enableScroll();
+      }
+
+      var imageElements = document.querySelectorAll(
+        '.wk-wysiwyg img:not([draggable="false"])'
+      );
+
+      imageElements.forEach(function(imageElement) {
+        imageElement.setAttribute("draggable", "false");
+      });
+    }
+
+    var observerConfig = { childList: true, subtree: true };
+    var wysiwygDivObserver = new MutationObserver(handleChange);
+
+    wysiwygDivObserver.observe(wysiwygDiv, observerConfig);
   }
 
 }


### PR DESCRIPTION
Dragging uploaded images would trigger an error modal.
With this change, images that are uploaded are not draggable and won't throw an error.

I also thought about performance, this will only select images that are draggable(newly uploaded images) and it won't select all images in the textarea.

![ezgif com-video-to-gif (5)](https://user-images.githubusercontent.com/35997844/72480809-e0bb2680-37f8-11ea-8582-f1e1e66d2416.gif)

Resolves #58 

@jywarren @IshaGupta18 @sagarpreet-chadha could you review this? Thanks.