### PR TITLE
FIX: Null inserted when closing Youtube modal

### DIFF
--- a/dist/PublicLab.Editor.js
+++ b/dist/PublicLab.Editor.js
@@ -21971,8 +21971,18 @@ module.exports = function initEmbed(_module, wysiwyg) {
   });
 
   $('.wk-commands .woofmark-command-embed').click(function() {
-    wysiwyg.runCommand(function(chunks, mode) {
-      chunks.before += _module.wysiwyg.parseMarkdown("\n\n\n" + prompt("Enter the full embed code offered by the originating site; for YouTube, that might be: <iframe width='100%' src='https://youtube.com/embed/_________' frameborder='0' allowfullscreen></iframe>") + "\n"); // newlines before and after
+    wysiwyg.runCommand(function (chunks, mode) {
+      var modalResult =
+        "\n\n\n" +
+        prompt(
+          "Enter the full embed code offered by the originating site; for YouTube, that might be: <iframe width='100%' src='https://youtube.com/embed/_________' frameborder='0' allowfullscreen></iframe>"
+        ) +
+        "\n";
+
+      // If a user cancels the modal
+      if (modalResult.trim() === 'null') return;
+
+      chunks.before += _module.wysiwyg.parseMarkdown(modalResult); // newlines before and after
       _module.afterParse(); // tell editor we're done here
     });
 

--- a/src/modules/PublicLab.RichTextModule.Embed.js
+++ b/src/modules/PublicLab.RichTextModule.Embed.js
@@ -12,8 +12,18 @@ module.exports = function initEmbed(_module, wysiwyg) {
   });
 
   $('.wk-commands .woofmark-command-embed').click(function() {
-    wysiwyg.runCommand(function(chunks, mode) {
-      chunks.before += _module.wysiwyg.parseMarkdown("\n\n\n" + prompt("Enter the full embed code offered by the originating site; for YouTube, that might be: <iframe width='100%' src='https://youtube.com/embed/_________' frameborder='0' allowfullscreen></iframe>") + "\n"); // newlines before and after
+    wysiwyg.runCommand(function (chunks, mode) {
+      var modalResult =
+        "\n\n\n" +
+        prompt(
+          "Enter the full embed code offered by the originating site; for YouTube, that might be: <iframe width='100%' src='https://youtube.com/embed/_________' frameborder='0' allowfullscreen></iframe>"
+        ) +
+        "\n";
+
+      // If a user cancels the modal
+      if (modalResult.trim() === 'null') return;
+
+      chunks.before += _module.wysiwyg.parseMarkdown(modalResult); // newlines before and after
       _module.afterParse(); // tell editor we're done here
     });
 


### PR DESCRIPTION
`prompt` function in JavaScript returns null if the "Cancel" button was pressed and returns the typed value if the "Ok" button was pressed. When the user clicks "Cancel", `null` is inserted in the textarea instead of nothing.

[Demo](https://streamable.com/lb80m)

Resolves #385 
