### PR TITLE
Add suggested tag names into tag-input when clicked.

### DIFF
--- a/dist/PublicLab.Editor.js
+++ b/dist/PublicLab.Editor.js
@@ -22454,14 +22454,14 @@ module.exports = PublicLab.RichTextModule = PublicLab.Module.extend({
       ) {
         wk_c.style.position = "relative";
         wk_c.style.bottom = 0 + "px";
-      } /*else {
+      } else {
         wk_c.style.bottom =
           document
             .getElementsByClassName("ple-footer")[0]
             .getBoundingClientRect().height + "px";
         wk_c.style.position = "fixed";
         wk_c.style.zIndex = 2;
-      }*/
+      }
     });
   }
 });

--- a/dist/PublicLab.Editor.js
+++ b/dist/PublicLab.Editor.js
@@ -22454,14 +22454,14 @@ module.exports = PublicLab.RichTextModule = PublicLab.Module.extend({
       ) {
         wk_c.style.position = "relative";
         wk_c.style.bottom = 0 + "px";
-      } else {
+      } /*else {
         wk_c.style.bottom =
           document
             .getElementsByClassName("ple-footer")[0]
             .getBoundingClientRect().height + "px";
         wk_c.style.position = "fixed";
         wk_c.style.zIndex = 2;
-      }
+      }*/
     });
   }
 });
@@ -22569,13 +22569,20 @@ module.exports = PublicLab.TagsModule = PublicLab.Module.extend({
       _module.options.recentTags.forEach(function(tag) {
 
         tags.push('<a>' + tag + '</a>');
-
       });
 
       _module.el.find('.ple-recent-tags')
                 .append(tags.join(', '))
 
       _module.el.find('.ple-help-minor').css('opacity','0');
+
+      //clicking on suggested tag would add the tag to tag input
+      $('.ple-recent-tags a').click(function() {
+       _module.el.find('input').tokenfield('createToken', this.textContent);
+         
+      });
+
+    
 
     }
 

--- a/src/modules/PublicLab.TagsModule.js
+++ b/src/modules/PublicLab.TagsModule.js
@@ -100,13 +100,20 @@ module.exports = PublicLab.TagsModule = PublicLab.Module.extend({
       _module.options.recentTags.forEach(function(tag) {
 
         tags.push('<a>' + tag + '</a>');
-
       });
 
       _module.el.find('.ple-recent-tags')
                 .append(tags.join(', '))
 
       _module.el.find('.ple-help-minor').css('opacity','0');
+
+      //clicking on suggested tag would add the tag to tag input
+      $('.ple-recent-tags a').click(function() {
+       _module.el.find('input').tokenfield('createToken', this.textContent);
+         
+      });
+
+    
 
     }
 


### PR DESCRIPTION
fixes #154
A suggested tag like `recent tags` will now be inputted into tag input when it is clicked on:
![Screenshot from 2020-04-03 12-54-38](https://user-images.githubusercontent.com/48386390/78362856-55a52d80-75aa-11ea-908b-9b3260477119.png)



Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt jasmine`
* [ ] code is in uniquely-named feature branch and has no merge conflicts
* [ ] PR is descriptively titled
* [ ] PR body includes `fixes #0000`-style reference to original issue #
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!