### PR TITLE
Added gitpod config

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,5 @@
+FROM gitpod/workspace-full
+                    
+USER gitpod
+
+RUN bash -c ". ~/.nvm/nvm-lazy.sh && npm install -g gulp-cli live-server"

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,16 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - init: |
+      npm install
+      npm run build
+    command: |
+      gp await-port 8080
+      gp preview http://localhost:8080/examples
+      npm run build
+  - command: |
+      npx live-server
+    openMode: split-right
+ports:
+  - port: 8080
+    onOpen: ignore

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@ PublicLab.Editor
 
 [![Build Status](https://travis-ci.org/publiclab/PublicLab.Editor.svg)](https://travis-ci.org/publiclab/PublicLab.Editor)
 [![Code of Conduct](https://img.shields.io/badge/code-of%20conduct-green.svg)](https://publiclab.org/conduct)
+[![Gitpod Ready-to-Code](https://img.shields.io/badge/Gitpod-Ready--to--Code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/publiclab/PublicLab.Editor) 
+
 Please contact [plots-dev@googlegroups.com](mailto:plots-dev@googlegroups.com) to get involved! We'd love to make this editor compatible with other platforms.
 
 PublicLab.Editor is a general purpose, modular JavaScript/Bootstrap UI library for rich text posting, which provides an author-friendly, minimal, mobile/desktop (fluid) interface for creating blog-like content, designed for [PublicLab.org](https://publiclab.org) (itself an [open source project](https://github.com/publiclab/plots2)).


### PR DESCRIPTION
Picking up where #483 left off: 

> Hi, I was pointed to your project and saw you were looking into adding gitpod support.
So here it is. I configured it so that it starts two terminals at start. The right one starts the live-server process and the left one is there to re-run the build (history up to get `npm run build`).
It also opens the preview on the examples directory at start.

> You can test it on my fork, by clicking this link: https://gitpod.io/#https://github.com/svenefftinge/PublicLab.Editor

> Fixes #475

> Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

> * [x] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt jasmine`
> * [x] PR is descriptively titled
> * [x] PR body includes `fixes #0000`-style reference to original issue #
