### PR TITLE
Lengthen jasmine and jest timeout for tests

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -48,7 +48,7 @@ module.exports = function(grunt) {
               allowFileAccess: true,
               sandboxArgs: {
                 args: ['--no-sandbox', '--allow-sync-xhr-in-page-dismissal'],
-                timeout: 3000
+                timeout: 30000
               },
               specs: 'spec/javascripts/*spec.js',
               vendor: [

--- a/spec/javascripts/editor_spec.js
+++ b/spec/javascripts/editor_spec.js
@@ -1,11 +1,11 @@
 var editor;
 
 describe("Editor", function() {
-  beforeAll(function() {
+  beforeAll(async function() {
     fixture = loadFixtures('index.html');
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
-    editor = new PL.Editor({
+    editor = await new PL.Editor({
       textarea: $('.ple-textarea')[0]
     });
   });

--- a/spec/javascripts/editor_spec.js
+++ b/spec/javascripts/editor_spec.js
@@ -1,12 +1,15 @@
 var editor;
 
 describe("Editor", function() {
-  beforeAll(async function() {
+  beforeAll((done) => {
     fixture = loadFixtures('index.html');
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
+    document.addEventListener("DOMContentLoaded", function(event) {
 
-    editor = await new PL.Editor({
-      textarea: $('.ple-textarea')[0]
+      editor = await new PL.Editor({
+        textarea: $('.ple-textarea')[0]
+      });
+
     });
   });
 

--- a/spec/javascripts/editor_spec.js
+++ b/spec/javascripts/editor_spec.js
@@ -3,6 +3,7 @@ var editor;
 describe("Editor", function() {
   beforeAll(function() {
     fixture = loadFixtures('index.html');
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
     editor = new PL.Editor({
       textarea: $('.ple-textarea')[0]

--- a/spec/javascripts/history_spec.js
+++ b/spec/javascripts/history_spec.js
@@ -3,6 +3,7 @@ var editor;
 describe("History", function() {
   beforeAll(function() {
     fixture = loadFixtures('index.html');
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
 
     editor = new PL.Editor({
       textarea: $('.ple-textarea')[0]

--- a/spec/javascripts/history_spec.js
+++ b/spec/javascripts/history_spec.js
@@ -1,12 +1,15 @@
 var editor;
 
 describe("History", function() {
-  beforeAll(function() {
+  beforeAll((done) => {
     fixture = loadFixtures('index.html');
     jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
+    document.addEventListener("DOMContentLoaded", function(event) {
 
-    editor = new PL.Editor({
-      textarea: $('.ple-textarea')[0]
+      editor = new PL.Editor({
+        textarea: $('.ple-textarea')[0]
+      });
+
     });
   });
 

--- a/spec/javascripts/tags_module_spec.js
+++ b/spec/javascripts/tags_module_spec.js
@@ -3,7 +3,8 @@ var editor; var module;
 describe("TagsModule", function() {
   beforeAll(function() {
     fixture = loadFixtures('index.html');
-
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 30000;
+    
     editor = new PL.Editor({
       textarea: $('.ple-textarea')[0]
     });

--- a/test/ui-testing/CustomInsert.test.js
+++ b/test/ui-testing/CustomInsert.test.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 beforeAll(async () => {
   path = fs.realpathSync('file://../examples/index.html');
   await page.goto('file://' + path, {waitUntil: 'domcontentloaded'});
+  await page.setDefaultNavigationTimeout(60000);
 });
 
 describe('Custom Insert text', () => {

--- a/test/ui-testing/bold.test.js
+++ b/test/ui-testing/bold.test.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 beforeAll(async () => {
   path = fs.realpathSync('file://../examples/index.html');
   await page.goto('file://' + path, {waitUntil: 'domcontentloaded'});
+  await page.setDefaultNavigationTimeout(60000);
 });
 
 describe('Bold Text', () => {

--- a/test/ui-testing/center.test.js
+++ b/test/ui-testing/center.test.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 beforeAll(async () => {
   path = fs.realpathSync('file://../examples/index.html');
   await page.goto('file://' + path, {waitUntil: 'domcontentloaded'});
+  await page.setDefaultNavigationTimeout(60000);
 });
 
 describe('Center Text', () => {

--- a/test/ui-testing/italic.test.js
+++ b/test/ui-testing/italic.test.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 beforeAll(async () => {
   path = fs.realpathSync('file://../examples/index.html');
   await page.goto('file://' + path, {waitUntil: 'domcontentloaded'});
+  await page.setDefaultNavigationTimeout(60000);
 });
 
 describe('Italic Text', () => {

--- a/test/ui-testing/title.test.js
+++ b/test/ui-testing/title.test.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 beforeAll(async () => {
   path = fs.realpathSync('file://../examples/index.html');
   await page.goto('file://' + path, {waitUntil: 'domcontentloaded'});
+  await page.setDefaultNavigationTimeout(60000);
 });
 
 describe('Title of the page', () => {


### PR DESCRIPTION
Try to fix #683 by lengthening timeouts for tests: 

```js
module.exports = {
  launch: {
    headless: process.env.HEADLESS !== 'false',
    slowMo: process.env.SLOWMO ? process.env.SLOWMO : 0,
    devtools: true
  },
  server: {
    command: 'grunt serve',
    port:3000,
    launchTimeout: 5000000,
  },
};
```

Note, this code may not work because we're just directly browsing the files without a local test server, so we really need to mess with the browser timeout, see below...