### PR TITLE
Adjust CSS styling of rich text toolbar

### DIFF
--- a/dist/PublicLab.Editor.js
+++ b/dist/PublicLab.Editor.js
@@ -22478,6 +22478,17 @@ module.exports = function(textarea, _editor, _module) {
         "btn btn-light"
     );
 
+    $('.wk-commands button.woofmark-command-bold').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-italic').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-quote').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-code').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-ol').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-ul').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-heading').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-link').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-image').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-attachment').addClass('btn-outline-secondary');
+
     $(".wk-commands button.woofmark-command-quote").addClass("hidden-xs");
     $(".wk-commands button.woofmark-command-code").addClass("hidden-xs");
     $(".wk-commands button.woofmark-command-ol").addClass("hidden-xs");

--- a/src/adapters/PublicLab.Woofmark.js
+++ b/src/adapters/PublicLab.Woofmark.js
@@ -335,6 +335,17 @@ module.exports = function(textarea, _editor, _module) {
         "btn btn-light"
     );
 
+    $('.wk-commands button.woofmark-command-bold').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-italic').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-quote').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-code').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-ol').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-ul').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-heading').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-link').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-image').addClass('btn-outline-secondary');
+    $('.wk-commands button.woofmark-command-attachment').addClass('btn-outline-secondary');
+
     $(".wk-commands button.woofmark-command-quote").addClass("hidden-xs");
     $(".wk-commands button.woofmark-command-code").addClass("hidden-xs");
     $(".wk-commands button.woofmark-command-ol").addClass("hidden-xs");


### PR DESCRIPTION
Fixes #664 
Some buttons were missing `btn-outline-secondary` class adding it fixed the problem 
![Screenshot from 2021-04-01 20-13-27](https://user-images.githubusercontent.com/38528640/113313381-cfd8d100-9328-11eb-9708-649f0d94e612.png)
