### PR TITLE
Changed the z-index of .wk-prompt to resolve the problem of map credits being overlayed on Insert Image popup.

### DIFF
--- a/dist/PublicLab.Editor.css
+++ b/dist/PublicLab.Editor.css
@@ -283,7 +283,7 @@ textarea.ple-textarea {
 .wk-prompt {
   border-radius: 10px;
   padding: 20px;
-  z-index: 999;
+  z-index: 10000;
 }
 
 /* Following may be removed if this is resolved:


### PR DESCRIPTION
…ts being overlayed on Insert Image popup.

Make sure these boxes are checked before your pull request (PR) is ready to be reviewed and merged. Thanks!

* [ ] tests pass -- look for a green checkbox ✔️ a few minutes after opening your PR -- or run tests locally with `grunt jasmine`
* [ ] code is in uniquely-named feature branch and has no merge conflicts
* [ ] PR is descriptively titled
* [ ] PR body includes `fixes #0000`-style reference to original issue #
* [ ] ask `@publiclab/reviewers` for help, in a comment below

> We're happy to help you get this ready -- don't be afraid to ask for help, and **don't be discouraged** if your tests fail at first!

If tests do fail, click on the red `X` to learn why by reading the logs.

Please be sure you've reviewed our contribution guidelines at https://publiclab.org/contributing-to-public-lab-software

We have a loose schedule of reviewing and pulling in changes every Tuesday and Friday, and publishing changes on Fridays. 

Thanks!
![image](https://user-images.githubusercontent.com/40101776/113588741-28bca800-964e-11eb-8e12-bf1fb20fbf9b.png)

[Issue: #9442](https://github.com/publiclab/plots2/issues/9442)