### PR TITLE
Converted errors jasmine test to jest test fixes #770

### DIFF
--- a/examples/errors.html
+++ b/examples/errors.html
@@ -17,6 +17,7 @@
     <link href="../dist/PublicLab.Editor.css" rel="stylesheet">
 
     <script src="../node_modules/jquery/dist/jquery.min.js"></script>
+    <script src="../node_modules/popper.js/dist/umd/popper.min.js" type="text/javascript"></script>
     <script src="../node_modules/bootstrap/dist/js/bootstrap.min.js"></script>
 
     <!-- required for TagsModule -->

--- a/test/ui-testing/errors.test.js
+++ b/test/ui-testing/errors.test.js
@@ -1,0 +1,20 @@
+const timeout = process.env.SLOWMO ? 60000 : 10000;
+const fs = require('fs');
+beforeAll(async () => {
+  path = fs.realpathSync('file://../examples/errors.html');
+  await page.goto('file://' + path, {waitUntil: 'domcontentloaded'});
+});
+
+describe('Errors', () => {
+  test('displays given errors', async () => {
+    expect( await page.evaluate(() => document.querySelectorAll('.ple-errors').length)).toBeGreaterThan(0);
+    expect( await page.evaluate(() => document.querySelectorAll('.ple-errors .alert').length)).toBe(1);
+    expect( await page.evaluate(() => document.querySelectorAll('.ple-errors p').length)).toBe(1);
+    expect( await page.evaluate(() => document.querySelector('.ple-errors p').innerText)).toBe("Error: title can't be blank.");
+  });
+
+  test("does not display error alert if there are no errors", async () => {
+    await page.evaluate(() => document.querySelector('.ple-errors').innerHTML = '');
+    expect( await page.evaluate(() => document.querySelectorAll('.ple-errors .alert').length) ).toBe(0);
+  });
+});


### PR DESCRIPTION
Hi, @jywarren @TildaDares trust you are well.
I was able to convert the errors jasmine test to jest test successfully and get all tests to pass but with a few caveats:
1. I had to do `page.goto(path to examples/errors.html)` as opposed to `examples/index.html` in the `errors_spec.js` file.
2. The `errors.html` file threw errors about `poppers.js` which bootstrap requires. I found that this is located at `../node_modules/popper.js/dist/umd/popper.min.js` and so I added a script for it in the `errors.html` file.

With these changes, the test ran successfully. Please have a look at the commits and let me know if this is fine or if I still need to make more changes.
Thank you!